### PR TITLE
rustfmt: make error_on_unformatted configurable in the action

### DIFF
--- a/rust-lint-and-format-action/action.yml
+++ b/rust-lint-and-format-action/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: 'Whether to enable reviewdog for rustfmt'
     required: false
     default: 'true'
+  error-on-unformatted:
+    description: 'Whether to treat unformatted code as an error in rustfmt'
+    required: false
+    default: 'true'
   reporter:
     description: 'Reporter to use for reviewdog'
     required: false
@@ -86,7 +90,7 @@ runs:
         FMT_EXIT=0
         cargo fmt -- \
           --emit=checkstyle \
-          --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true \
+          --config error_on_unformatted=${{ inputs.error-on-unformatted }},error_on_line_overflow=true,format_strings=true \
           --config group_imports=StdExternalCrate \
           --config imports_granularity=Crate \
           --config hex_literal_case=Upper \
@@ -124,7 +128,7 @@ runs:
       run: |
         cargo fmt -- \
           --check \
-          --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true \
+          --config error_on_unformatted=${{ inputs.error-on-unformatted }},error_on_line_overflow=true,format_strings=true \
           --config group_imports=StdExternalCrate \
           --config imports_granularity=Crate \
           --config hex_literal_case=Upper


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Makes error_on_unformatted configurable in the action (default true)

When using sphinx codelinks, some comment lines aren't wrappable, so we need to exceed the default limits.
Unfortunately we haven't found a way to do this more selectively.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
