### PR TITLE
fix: handle URLError for network/offline failures

### DIFF
--- a/run_checks.py
+++ b/run_checks.py
@@ -353,6 +353,19 @@ def main():
             Path(config_path).unlink(missing_ok=True)
         cleanup_downloads(cleanup_list)
         sys.exit(1)
+    except urllib.error.URLError as e:
+        print(
+            f"Network error: {e.reason}",
+            file=sys.stderr,
+        )
+        print(
+            "Could not reach GitHub. Please check your internet connection and try again.",
+            file=sys.stderr,
+        )
+        if config_is_temp and config_path:
+            Path(config_path).unlink(missing_ok=True)
+        cleanup_downloads(cleanup_list)
+        sys.exit(1)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         if config_is_temp and config_path:


### PR DESCRIPTION
fix: handle URLError for network/offline failures

Previously, running run_checks.py without internet would produce a raw
Python traceback. The existing HTTPError handler only catches HTTP-level
errors (404, 403, etc.) — not connection-level failures such as no
network, DNS resolution errors, or connection refused.

Add a specific urllib.error.URLError handler in main() that catches
these network-level failures and prints a clear "check your internet
connection" message instead of an unhelpful traceback.

Signed-off-by: sharanamma hosur <h.sharanamma@gmail.com>