### PR TITLE
fix: replace ComPWA taplo-pre-commit hook with direct system taplo calls

### DIFF
--- a/pre-commit-action/.pre-commit-config.yml
+++ b/pre-commit-action/.pre-commit-config.yml
@@ -31,11 +31,20 @@ repos:
         args: [--output-format=full]
       - id: ruff-format
         args: [--diff]
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: v0.9.3
+  - repo: local
     hooks:
       - id: taplo-format
+        name: taplo-format
+        description: Format TOML documents
+        entry: taplo format
+        language: system
+        types: [toml]
       - id: taplo-lint
+        name: taplo-lint
+        description: Lint TOML documents
+        entry: taplo lint
+        language: system
+        types: [toml]
   - repo: https://github.com/fsfe/reuse-tool
     rev: v6.2.0
     hooks:

--- a/pre-commit-action/action.yml
+++ b/pre-commit-action/action.yml
@@ -96,6 +96,10 @@ runs:
       shell: bash
       run: uv tool install reuse
 
+    - name: Install taplo
+      shell: bash
+      run: uv tool install taplo
+
     - name: Run checks
       shell: bash
       run: |


### PR DESCRIPTION
## Problem

The `ComPWA/taplo-pre-commit` hook runs `taplo lint --default-schema-catalogs`, which forces taplo to fetch a remote schema catalog. This fetch fails at runtime with:

```
WARN taplo: failed to fetch catalog error=error decoding response body: data did not match any variant of untagged enum SchemaCatalog

Caused by:
    data did not match any variant of untagged enum SchemaCatalog
ERROR operation failed error=failed to load schema catalog: error decoding response body: data did not match any variant of untagged enum SchemaCatalog: data did not match any variant of untagged enum SchemaCatalog
```

The hook also provides no way to disable schema catalog fetching — `--default-schema-catalogs` cannot be suppressed through hook configuration.

## Solution

Replace the `ComPWA/taplo-pre-commit` hook with direct `language: system` invocations of `taplo format` and `taplo lint` that do not pass `--default-schema-catalogs`. A `uv tool install taplo` step is added to `action.yml` to ensure `taplo` is available in `PATH` during CI (uv is already set up in the action).



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)