### PR TITLE
feat: add no-unicode-extensions check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,10 @@ on:
         description: 'Name of reuse Jinja2 template in .reuse/templates/ (without .jinja2 suffix), defaults to "opensovd"'
         required: false
         type: string
+      no-unicode-extensions:
+        description: 'Comma-separated file extensions to check for non-ASCII characters (e.g., ".py,.rs"). Empty string disables the check.'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -63,3 +67,4 @@ jobs:
           copyright-text: ${{ inputs.copyright-text }}
           license: ${{ inputs.license }}
           reuse-template: ${{ inputs.reuse-template }}
+          no-unicode-extensions: ${{ inputs.no-unicode-extensions }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
       copyright-text: ""  # Optional, defaults to "The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)"
       license: ""  # Optional, defaults to "Apache-2.0"
       reuse-template: ""  # Optional, defaults to "opensovd"
+      no-unicode-extensions: ""  # Optional, e.g. ".py,.rs,.c"; disabled by default
 ```
 
 #### Available Inputs
@@ -59,6 +60,7 @@ jobs:
 - `copyright-text` (optional): Copyright holder text for `reuse annotate` (e.g. `"ACME Inc."`). Defaults to `"The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)"`.
 - `license` (optional): SPDX license identifier for `reuse annotate` (e.g. `"MIT"`). Defaults to `"Apache-2.0"`.
 - `reuse-template` (optional): Name of the Jinja2 template in `.reuse/templates/` (without `.jinja2` suffix). Consumer repos can provide their own template. Defaults to `"opensovd"`.
+- `no-unicode-extensions` (optional): Comma-separated list of file extensions (e.g. `".py,.rs,.c"`) whose contents are checked for non-ASCII bytes. Any file with a matching extension that contains a byte with value > 127 causes the check to fail with the offending file path and line number reported. Extensions may include or omit the leading dot. Disabled by default (empty string).
 
 ### Using Individual Actions
 
@@ -158,6 +160,7 @@ When a formatter makes changes to your code, the pre-commit hook fails, requirin
 - `copyright-text`: Copyright holder text for `reuse annotate` (default: `"The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)"`)
 - `license`: SPDX license identifier for `reuse annotate` (default: `"Apache-2.0"`)
 - `reuse-template`: Name of Jinja2 template in `.reuse/templates/` (default: `"opensovd"`)
+- `no-unicode-extensions`: Comma-separated file extensions to check for non-ASCII characters (e.g. `".py,.rs,.c"`). Disabled by default (empty string). When enabled, any file with a matching extension containing a byte > 127 fails the check.
 
 
 ## Running Checks Locally
@@ -196,6 +199,13 @@ uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/ru
 ```bash
 uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py --copyright="ACME Inc." --license=MIT --template=mytemplate
 ```
+
+###### Check for non-ASCII characters in specific file types
+```bash
+uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py --no-unicode-extensions=".py,.rs"
+```
+
+The `--no-unicode-extensions` flag accepts a comma-separated list of file extensions (with or without a leading dot). When provided, any file with a matching extension that contains a non-ASCII byte (value > 127) causes the check to fail, reporting the file path and line number. Omit the flag or pass an empty string to disable this check.
 
 The script automatically fixes ruff lint violations and applies ruff formatting. In CI, issues are only reported without auto-fix.
 

--- a/pre-commit-action/action.yml
+++ b/pre-commit-action/action.yml
@@ -45,6 +45,11 @@ inputs:
       Comma-separated list of file patterns to ignore during REUSE checks (e.g., "*.md,docs/**,*.txt"). Files matching these patterns will be skipped by reuse annotate.
     required: false
     default: ''
+  no-unicode-extensions:
+    description: >
+      Comma-separated list of file extensions to check for non-ASCII characters (e.g., ".py,.rs,.c"). When non-empty, any file with a matching extension that contains a byte > 127 will cause the check to fail. Disabled by default (empty string).
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -109,4 +114,5 @@ runs:
           --copyright="${{ inputs.copyright-text }}" \
           --license="${{ inputs.license }}" \
           --template="${{ inputs.reuse-template }}" \
-          --ignore-paths="${{ inputs.ignore-paths }}"
+          --ignore-paths="${{ inputs.ignore-paths }}" \
+          --no-unicode-extensions="${{ inputs.no-unicode-extensions }}"

--- a/pre-commit-action/no-unicode-check.py
+++ b/pre-commit-action/no-unicode-check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+import sys
+
+
+def check_file(path):
+    """Return a list of 1-indexed line numbers on which non-ASCII bytes are found.
+
+    Returns None if the file cannot be read (error already printed to stderr).
+    """
+    line_numbers = []
+    try:
+        with open(path, "rb") as f:
+            for line_number, line in enumerate(f, start=1):
+                if any(byte > 127 for byte in line):
+                    line_numbers.append(line_number)
+    except OSError as e:
+        print(f"Error reading {path}: {e}", file=sys.stderr)
+        return None
+    return line_numbers
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(0)
+
+    found_violations = False
+    for path in sys.argv[1:]:
+        line_numbers = check_file(path)
+        if line_numbers is None:
+            found_violations = True
+            continue
+        if line_numbers:
+            found_violations = True
+            for line_number in line_numbers:
+                print(f"{path}:{line_number}: non-ASCII character found")
+
+    sys.exit(1 if found_violations else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_checks.py
+++ b/run_checks.py
@@ -33,6 +33,9 @@ REPO_BASE_URL = (
 )
 CONFIG_URL_TEMPLATE = f"{REPO_BASE_URL}/pre-commit-action/.pre-commit-config.yml"
 HOOK_SCRIPT_URL_TEMPLATE = f"{REPO_BASE_URL}/pre-commit-action/reuse-annotate-hook.py"
+NO_UNICODE_CHECK_SCRIPT_URL_TEMPLATE = (
+    f"{REPO_BASE_URL}/pre-commit-action/no-unicode-check.py"
+)
 TEMPLATE_URL_TEMPLATE = f"{REPO_BASE_URL}/.reuse/templates/{{template}}.jinja2"
 LICENSE_URL_TEMPLATE = f"{REPO_BASE_URL}/LICENSES/{{license}}.txt"
 REUSE_TOML_URL_TEMPLATE = f"{REPO_BASE_URL}/REUSE.toml"
@@ -43,7 +46,7 @@ CLIPPY_LINTS_CHECK_SCRIPT_URL_TEMPLATE = (
 )
 
 
-def patch_config(config_content, *, fix_mode):
+def patch_config(config_content, *, fix_mode, no_unicode_extensions=""):
     """Patch the pre-commit config for fix mode vs check-only mode.
 
     In fix mode (local), ruff auto-fixes issues in place.
@@ -65,6 +68,24 @@ def patch_config(config_content, *, fix_mode):
             "cargo fmt --check",
             "cargo fmt",
         )
+
+    if no_unicode_extensions:
+        parts = [
+            e.strip().lstrip(".")
+            for e in no_unicode_extensions.split(",")
+            if e.strip().lstrip(".")
+        ]
+        if parts:
+            files_regex = r"\\.(" + "|".join(parts) + r")$"
+            hook_block = (
+                "      - id: no-unicode-check\n"
+                "        name: No Unicode characters allowed\n"
+                "        entry: python no-unicode-check.py\n"
+                "        language: system\n"
+                f"        files: '{files_regex}'\n"
+                "        pass_filenames: true\n"
+            )
+            config_content = config_content.rstrip("\n") + "\n" + hook_block
 
     return config_content
 
@@ -190,6 +211,11 @@ def main():
         default="",
         help="Comma-separated list of file patterns to ignore during REUSE checks (e.g., '*.md,docs/**,*.txt')",
     )
+    parser.add_argument(
+        "--no-unicode-extensions",
+        default="",
+        help="Comma-separated file extensions to check for non-ASCII characters (e.g., '.py,.rs'). Empty string disables the check.",
+    )
 
     args = parser.parse_args()
 
@@ -218,14 +244,22 @@ def main():
             ) as f:
                 with urllib.request.urlopen(config_url) as response:
                     config_content = response.read().decode()
-                config_content = patch_config(config_content, fix_mode=fix_mode)
+                config_content = patch_config(
+                    config_content,
+                    fix_mode=fix_mode,
+                    no_unicode_extensions=args.no_unicode_extensions,
+                )
                 f.write(config_content)
                 config_path = f.name
             config_is_temp = True
         else:
             # Local config provided: always patch a temp copy to inject settings
             config_content = Path(config_path).read_text()
-            config_content = patch_config(config_content, fix_mode=fix_mode)
+            config_content = patch_config(
+                config_content,
+                fix_mode=fix_mode,
+                no_unicode_extensions=args.no_unicode_extensions,
+            )
             with tempfile.NamedTemporaryFile(
                 mode="w", suffix=".yml", delete=False
             ) as f:
@@ -267,6 +301,17 @@ def main():
         # Clean up if we created the file (downloaded or copied from elsewhere)
         if not hook_existed_in_cwd:
             cleanup_list.append({"file": hook_cwd_path, "dirs": []})
+
+        # Ensure no-unicode-check.py is in CWD when the feature is enabled so
+        # the pre-commit entry 'python no-unicode-check.py' resolves correctly.
+        if args.no_unicode_extensions:
+            cleanup_list.append(
+                download_if_missing(
+                    Path("no-unicode-check.py"),
+                    NO_UNICODE_CHECK_SCRIPT_URL_TEMPLATE.format(branch=branch),
+                    "no-unicode-check script",
+                )
+            )
 
         # Ensure REUSE assets are available locally
         reuse_toml_url = REUSE_TOML_URL_TEMPLATE.format(branch=branch)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add an optional, disabled-by-default check that fails when files with
user-specified extensions contain any non-ASCII (unicode) character.

The feature is exposed as a single input `no-unicode-extensions` (comma-separated
list of file extensions, e.g. `".c,.h,.cpp"`) on three surfaces:

- `pre-commit-action/action.yml` — composite GitHub Action input
- `.github/workflows/checks.yml` — reusable workflow `workflow_call` input
- `run_checks.py` — `--no-unicode-extensions` CLI argument for local runs

When the input is empty (the default), no check is performed and existing
behaviour is completely unchanged. When extensions are provided, a new local
pre-commit hook (`no-unicode-check.py`) is injected into the pre-commit config
at runtime. The hook reads each matching file in binary mode, reports every
line containing a byte > 127 (file path + line number), and exits with code 1
on any violation. There is no auto-fix; the failure is hard in both CI and
local modes.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation

## Related

N/A

## Notes for Reviewers

The hook script is injected dynamically into the pre-commit config string
(via an extended `patch_config()`) and the script itself is copied to the
consumer's CWD via `download_if_missing()` — the same pattern used for
`reuse-annotate-hook.py`. When the feature is disabled (empty input), none
of this code path is reached.



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)