### PR TITLE
feat: add reusable tauri-release workflow

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Tauri Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_call:
+    inputs:
+      app-name:
+        description: >
+          Human-readable release name prefix, e.g. "MDD UI". Used in releaseName: "<app-name> ${{ github.ref_name }}".
+        type: string
+        required: true
+
+      app-binary-name:
+
+      tauri-conf-path:
+        description: "Relative path to tauri.conf.json (default: tauri.conf.json)"
+        type: string
+        default: "tauri.conf.json"
+
+      cargo-toml-path:
+        description: "Relative path to Cargo.toml (default: Cargo.toml)"
+        type: string
+        default: "Cargo.toml"
+
+      frontend-dir:
+        description: "Directory that contains package.json (default: frontend)"
+        type: string
+        default: "frontend"
+
+      package-manager:
+        description: "Frontend package manager: 'bun' or 'npm' (default: bun)"
+        type: string
+        default: "bun"
+
+      bun-version:
+        description: "Bun version to install when package-manager is 'bun' (default: latest)"
+        type: string
+        default: "latest"
+
+      node-version:
+        description: "Node.js version to install when package-manager is 'npm' (default: 22)"
+        type: string
+        default: "22"
+
+      rust-version:
+        description: "Rust toolchain version (default: stable)"
+        type: string
+        default: "stable"
+
+      tauri-action-version:
+        description: "Version of tauri-apps/tauri-action to use (default: v0)"
+        type: string
+        default: "v0"
+
+      release-draft:
+        description: "Publish release as a draft (default: false)"
+        type: boolean
+        default: false
+
+      prerelease:
+        description: "Mark release as a pre-release (default: false)"
+        type: boolean
+        default: false
+
+      build-linux:
+        description: "Include the Linux (ubuntu-latest) build (default: true)"
+        type: boolean
+        default: true
+
+      build-macos-arm:
+        description: "Include the macOS aarch64 build (default: true)"
+        type: boolean
+        default: true
+
+      build-windows:
+        description: "Include the Windows x64 build (default: true)"
+        type: boolean
+        default: true
+
+      signing-private-key-secret:
+        description: >
+          Name of the repository / org secret that holds the Tauri signing private key (TAURI_SIGNING_PRIVATE_KEY). Leave empty to skip signing.
+        type: string
+        default: "TAURI_SIGNING_PRIVATE_KEY"
+
+      signing-private-key-password-secret:
+        description: >
+          Name of the repository / org secret that holds the Tauri signing private key password (TAURI_SIGNING_PRIVATE_KEY_PASSWORD).
+        type: string
+        default: "TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+
+    secrets:
+      TAURI_SIGNING_PRIVATE_KEY:
+        description: "Tauri signing private key (optional)"
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        description: "Tauri signing private key password (optional)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            args: ""
+            rust_targets: ""
+            enabled: ${{ inputs.build-linux }}
+          - platform: macos-latest
+            args: "--target aarch64-apple-darwin"
+            rust_targets: "aarch64-apple-darwin"
+            enabled: ${{ inputs.build-macos-arm }}
+          - platform: windows-latest
+            args: ""
+            rust_targets: ""
+            enabled: ${{ inputs.build-windows }}
+
+    runs-on: ${{ matrix.platform }}
+    if: ${{ matrix.enabled }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Inject version from tag
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 - << 'EOF'
+          import os, re, json
+
+          v = os.environ.get("VERSION") or os.environ.get("GITHUB_REF_NAME", "").lstrip("v")
+          tauri_conf = "${{ inputs.tauri-conf-path }}"
+          cargo_toml = "${{ inputs.cargo-toml-path }}"
+
+          with open(tauri_conf) as f:
+              cfg = json.load(f)
+          cfg["version"] = v
+          with open(tauri_conf, "w") as f:
+              json.dump(cfg, f, indent=2)
+              f.write("\n")
+
+          with open(cargo_toml) as f:
+              text = f.read()
+          # Replace version only in [package] section (first occurrence)
+          text = re.sub(r'^version = "[^"]+"', f'version = "{v}"', text, count=1, flags=re.MULTILINE)
+          with open(cargo_toml, "w") as f:
+              f.write(text)
+          EOF
+        env:
+          VERSION: ${{ github.ref_name }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          targets: ${{ matrix.rust_targets }}
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            libssl-dev \
+            libxdo-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Set up Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Set up Node.js
+        if: inputs.package-manager == 'npm'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install frontend dependencies (bun)
+        if: inputs.package-manager == 'bun'
+        run: bun install
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Install frontend dependencies (npm)
+        if: inputs.package-manager == 'npm'
+        run: npm ci
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Build and upload Tauri bundles
+        uses: tauri-apps/tauri-action@${{ inputs.tauri-action-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
+          releaseDraft: ${{ inputs.release-draft }}
+          prerelease: ${{ inputs.prerelease }}
+          args: ${{ matrix.args }}
+
+  merge-updater-json:
+    needs:
+      - build-tauri
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Rename assets and generate latest.json
+        uses: actions/github-script@v7
+        env:
+          APP_BINARY_NAME: ${{ inputs.app-binary-name }}
+        with:
+          script: |
+            const tagName   = context.ref.replace('refs/tags/', '');
+            const version   = tagName.replace(/^v/, '');
+            const owner     = context.repo.owner;
+            const repo      = context.repo.repo;
+            const bin       = process.env.APP_BINARY_NAME;   // e.g. "mdd-ui"
+            // Tauri uses underscores in some asset names and hyphens in others.
+            // Build both variants to match reliably.
+            const binU      = bin.replace(/-/g, '_');         // e.g. "mdd_ui"
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag: tagName });
+            const releaseId = release.id;
+
+            const { data: assets } = await github.rest.repos.listReleaseAssets({
+              owner, repo, release_id: releaseId, per_page: 100,
+            });
+
+            // Each rule matches the Tauri-generated bundle name, provides the
+            // new name (with OS/arch identifier) and the updater platform
+            // key — null means the bundle is for direct download only.
+            const bundleRules = [
+              // ── macOS aarch64 ──────────────────────────────────────────────
+              {
+                match:      new RegExp(`^${bin}_aarch64\\.app\\.tar\\.gz$`, 'i'),
+                newName:    `${bin}_${version}_darwin_aarch64.app.tar.gz`,
+                updaterKey: 'darwin-aarch64-app',
+              },
+              {
+                match:      new RegExp(`^${bin}_[\\d.]+_aarch64\\.dmg$`, 'i'),
+                newName:    `${bin}_${version}_darwin_aarch64.dmg`,
+                updaterKey: null,
+              },
+              // ── Linux x86_64 ───────────────────────────────────────────────
+              {
+                match:      new RegExp(`^${binU}_[\\d.]+_amd64\\.AppImage$`, 'i'),
+                newName:    `${bin}_${version}_linux_amd64.AppImage`,
+                updaterKey: 'linux-x86_64',
+              },
+              {
+                match:      new RegExp(`^${binU}_[\\d.]+_amd64\\.deb$`, 'i'),
+                newName:    `${bin}_${version}_linux_amd64.deb`,
+                updaterKey: null,
+              },
+              {
+                match:      new RegExp(`^${bin}-[\\d.]+-1\\.x86_64\\.rpm$`, 'i'),
+                newName:    `${bin}-${version}-1_linux_x86_64.rpm`,
+                updaterKey: null,
+              },
+              // ── Windows x64 ───────────────────────────────────────────────
+              {
+                match:      new RegExp(`^${binU}_[\\d.]+_x64-setup\\.exe$`, 'i'),
+                newName:    `${bin}_${version}_windows_x64-setup.exe`,
+                updaterKey: 'windows-x86_64',
+              },
+              {
+                match:      new RegExp(`^${binU}_[\\d.]+_x64_en-US\\.msi$`, 'i'),
+                newName:    `${bin}_${version}_windows_x64_en-US.msi`,
+                updaterKey: null,
+              },
+            ];
+
+            const platforms = {};
+
+            for (const rule of bundleRules) {
+              const bundle = assets.find(a => rule.match.test(a.name));
+              if (!bundle) {
+                core.warning(`No asset matched pattern ${rule.match} — skipping`);
+                continue;
+              }
+
+              // Rename bundle (no binary download required)
+              const { data: renamed } = await github.rest.repos.updateReleaseAsset({
+                owner, repo, asset_id: bundle.id, name: rule.newName,
+              });
+              core.info(`Renamed: ${bundle.name} → ${rule.newName}`);
+
+              // Rename the companion .sig file if present
+              const sig = assets.find(a => a.name === `${bundle.name}.sig`);
+              if (sig) {
+                await github.rest.repos.updateReleaseAsset({
+                  owner, repo, asset_id: sig.id, name: `${rule.newName}.sig`,
+                });
+                core.info(`Renamed: ${sig.name} → ${rule.newName}.sig`);
+
+                if (rule.updaterKey) {
+                  const sigResp = await github.request(
+                    `GET /repos/${owner}/${repo}/releases/assets/${sig.id}`,
+                    { headers: { accept: 'application/octet-stream' } },
+                  );
+                  const signature = Buffer.from(sigResp.data).toString('utf-8').trim();
+                  platforms[rule.updaterKey] = { signature, url: renamed.browser_download_url };
+                }
+              } else if (rule.updaterKey) {
+                core.warning(`No .sig found for ${bundle.name} — skipping updater entry`);
+              }
+            }
+
+            if (Object.keys(platforms).length === 0) {
+              core.setFailed('No updater platform entries found — cannot generate latest.json');
+              return;
+            }
+
+            const updaterJson = {
+              version: `v${version}`,
+              notes:   '',
+              pub_date: new Date().toISOString(),
+              platforms,
+            };
+
+            // Remove stale latest.json uploaded per-platform by tauri-action
+            const existing = assets.find(a => a.name === 'latest.json');
+            if (existing) {
+              await github.rest.repos.deleteReleaseAsset({
+                owner, repo, asset_id: existing.id,
+              });
+            }
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner, repo, release_id: releaseId,
+              name: 'latest.json',
+              data: JSON.stringify(updaterJson, null, 2),
+            });
+
+            core.info(`Uploaded latest.json with platforms: ${Object.keys(platforms).join(', ')}`);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Generalizes the Tauri v2 release pipeline from `alexmohr/mdd-ui` into a shared, fully-parameterized reusable `workflow_call` workflow. All app-specific values are inputs — nothing is hard-coded. Consumers reference it with `uses: eclipse-opensovd/cicd-workflows/.github/workflows/tauri-release.yml@<sha>`.

This in in preparation to move MDD ui into opensovd. This workflow. Can be used for all tauri UIs

**Job 1 — `build-tauri`** (matrix: Linux / macOS aarch64 / Windows)
- Injects the tag version into `tauri.conf.json` and `Cargo.toml`
- Installs the configured Rust toolchain + Bun
- Installs Linux system deps (webkit2gtk, appindicator, …) on Ubuntu only
- Calls `tauri-apps/tauri-action` to build and upload bundles to the GitHub release

**Job 2 — `merge-updater-json`** (runs after all matrix builds)
- Renames Tauri's raw artefact names to stable, OS/arch-suffixed names
- Collects `.sig` files and builds a `latest.json` for the Tauri updater
- Uploads the final `latest.json` to the release (replacing any per-platform stubs)

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Companion PR: [alexmohr/mdd-ui#30](https://github.com/alexmohr/mdd-ui/pull/30)

## Notes for Reviewers

All app-specific values are workflow inputs — nothing is hardcoded in the shared workflow. The companion PR in `mdd-ui` demonstrates example usage.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)