### PR TITLE
refactor: unify cleanup logic into finally block in run_checks.py

### DIFF
--- a/run_checks.py
+++ b/run_checks.py
@@ -337,11 +337,6 @@ def main():
             check=False,
             env=env,
         )
-
-        # Clean up
-        if config_is_temp:
-            Path(config_path).unlink(missing_ok=True)
-        cleanup_downloads(cleanup_list)
         sys.exit(result.returncode)
     except urllib.error.HTTPError as e:
         print(f"Error downloading config: {e}", file=sys.stderr)
@@ -349,9 +344,6 @@ def main():
             f"Make sure the branch '{branch}' exists in the repository.",
             file=sys.stderr,
         )
-        if config_is_temp and config_path:
-            Path(config_path).unlink(missing_ok=True)
-        cleanup_downloads(cleanup_list)
         sys.exit(1)
     except urllib.error.URLError as e:
         print(
@@ -362,16 +354,14 @@ def main():
             "Could not reach GitHub. Please check your internet connection and try again.",
             file=sys.stderr,
         )
-        if config_is_temp and config_path:
-            Path(config_path).unlink(missing_ok=True)
-        cleanup_downloads(cleanup_list)
         sys.exit(1)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
         if config_is_temp and config_path:
             Path(config_path).unlink(missing_ok=True)
         cleanup_downloads(cleanup_list)
-        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- The cleanup of the temporary pre-commit config file and all downloaded assets was duplicated across the success path and all three `except` branches (`HTTPError`, `URLError`, `Exception`)
- Consolidate into a single `finally` block, eliminating 12 lines of repetition
- Behaviour is identical: cleanup always runs, exit codes are unchanged

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related


## Notes for Reviewers

Pure refactor — no functional change. The `finally` block runs unconditionally (including on `sys.exit`), so cleanup is guaranteed on all code paths.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)