### PR TITLE
fix:correct guard cleanup_list in run_checks.py

### DIFF
--- a/run_checks.py
+++ b/run_checks.py
@@ -434,7 +434,8 @@ def main():
     finally:
         if config_is_temp and config_path:
             Path(config_path).unlink(missing_ok=True)
-        cleanup_downloads(cleanup_list)
+        if cleanup_list:
+            cleanup_downloads(cleanup_list)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The finally block refernces config_is_temp, config_path, and cleanup_list.If an exception is raised before these varables are assigned inside try , the finally block will throw a NameError masking the original error.
To Guard cleanup_list in case it's not yet defined when an early exception fires.

Signed off : h.sharanamma@gmail.com