### PR TITLE
fix: enforce current year in copyright header of new files

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,10 @@ When a formatter makes changes to your code, the pre-commit hook fails, requirin
 
 #### In This Repository
 
-
-
 To run pre-commit checks locally in this repository:
 
 ```bash
-uv tool run pre-commit@4.2 run --all-files --config pre-commit-action/.pre-commit-config.yml
+uv run pr-commit.py
 ```
 
 #### In Your Repository (Using This Action's Config)
@@ -187,49 +185,48 @@ You have two options to run the same checks locally that run in CI:
 ##### Option 1: Using the `run_checks.py` script (One-off execution)
 
 ```bash
-# Run with the default 'main' branch config
+# Pin to a specific commit SHA (recommended for reproducibility)
+uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/<SHA>/run_checks.py
+
+# Or use the default 'main' branch
 uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py
 ```
 
-###### Specify a different branch/tag/commit
+###### Specify a different branch, tag, or commit SHA
 ```bash
-uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py your-branch-name
+uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py your-branch-or-sha
 ```
-
-###### Custom copyright and license
-```bash
-uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py --copyright="ACME Inc." --license=MIT --template=mytemplate
-```
-
-###### Check for non-ASCII characters in specific file types
-```bash
-uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py --no-unicode-extensions=".py,.rs"
-```
-
-To allow specific Unicode characters (e.g. `µ` and `§`):
-```bash
-uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py --no-unicode-extensions=".py,.rs" --allowed-unicode-chars="µ,§"
-```
-
-The `--no-unicode-extensions` flag accepts a comma-separated list of file extensions (with or without a leading dot). When provided, any file with a matching extension that contains a non-ASCII byte (value > 127) causes the check to fail, reporting the file path and line number. The `--allowed-unicode-chars` flag accepts a comma-separated list of Unicode characters that are exempt from this check. Omit the flags or pass empty strings to disable.
-
-The script automatically fixes ruff lint violations and applies ruff formatting. In CI, issues are only reported without auto-fix.
-
 
 #### Option 2: Using pre-commit directly (Recommended for development)
 
-Create a `.pre-commit-config.yaml` file in your repository root:
+Create a `.pre-commit-config.yaml` file in your repository root. Pin hook entry URLs to a specific commit SHA for reproducibility:
 
 ```yaml
 repos:
   - repo: local
     hooks:
-      - id: shared-checks
-        name: Shared pre-commit checks
-        entry: uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py
+      - id: reuse-annotate
+        name: Add missing license headers (REUSE)
+        # Replace <SHA> with a pinned commit from eclipse-opensovd/cicd-workflows
+        entry: uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/<SHA>/pre-commit-action/reuse-annotate-hook.py
+        args:
+          - --copyright=Your Copyright Holder
+          - --license=Apache-2.0
+          - --template=your-template
+          - --ignore-paths=docs/**,*.md
         language: system
-        pass_filenames: false
+        pass_filenames: true
+        exclude: ^(LICENSE|NOTICE|CONTRIBUTORS)$
+      - id: no-unicode-check
+        name: No Unicode characters allowed
+        entry: uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/<SHA>/pre-commit-action/no-unicode-check.py
+        args: [--allowed-chars=µ,§]
+        language: system
+        files: '\.(py|rs|toml|yml)$'
+        pass_filenames: true
 ```
+
+The `--copyright`, `--license`, `--template`, and `--ignore-paths` args on `reuse-annotate` must match the values used in your `checks.yml` workflow inputs.
 
 Then install and use pre-commit normally:
 
@@ -244,14 +241,9 @@ pre-commit run --all-files
 pre-commit run
 ```
 
-**Custom Config**: If you've specified a custom `pre-commit-config-path` in your workflow, you can run pre-commit directly:
+**Run Specific Hooks**: To run only the annotate hook:
 ```bash
-uv tool run pre-commit@4.2 run --all-files --config .pre-commit-config.yml
-```
-
-**Run Specific Hooks**: To run only the shared checks:
-```bash
-pre-commit run shared-checks --all-files
+pre-commit run reuse-annotate --all-files
 ```
 
 ### Installing Required Tools

--- a/pr-commit.py
+++ b/pr-commit.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+# /// script
+# dependencies = ["pre-commit==4.2"]
+# ///
+
+import runpy
+import sys
+from pathlib import Path
+
+sys.argv[0] = "run_checks.py"
+runpy.run_path(Path(__file__).parent / "run_checks.py", run_name="__main__")

--- a/pre-commit-action/.pre-commit-config.yml
+++ b/pre-commit-action/.pre-commit-config.yml
@@ -54,6 +54,11 @@ repos:
       - id: reuse-annotate
         name: Add missing license headers (REUSE)
         entry: uv run reuse-annotate-hook.py
+        args:
+          - --copyright=The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+          - --license=Apache-2.0
+          - --template=opensovd
+          - --ignore-paths=
         language: system
         pass_filenames: true
         exclude: ^(LICENSE|NOTICE|CONTRIBUTORS)$

--- a/pre-commit-action/action.yml
+++ b/pre-commit-action/action.yml
@@ -112,14 +112,8 @@ runs:
 
     - name: Run checks
       shell: bash
+      env:
+        SKIP: reuse-annotate
       run: |
-        uv run "${GITHUB_ACTION_PATH}/../run_checks.py" --no-fix \
-          ${{ steps.inputs.outputs.config_flag }} \
-          --hook-script="${GITHUB_ACTION_PATH}/reuse-annotate-hook.py" \
-          --copyright="${{ inputs.copyright-text }}" \
-          --license="${{ inputs.license }}" \
-          --template="${{ inputs.reuse-template }}" \
-          --ignore-paths="${{ inputs.ignore-paths }}" \
-          --no-unicode-extensions="${{ inputs.no-unicode-extensions }}" \
-          --allowed-unicode-chars="${{ inputs.allowed-unicode-chars }}" \
-          --no-unicode-check-script="${GITHUB_ACTION_PATH}/no-unicode-check.py"
+        uv run "${GITHUB_ACTION_PATH}/../run_checks.py" \
+          ${{ steps.inputs.outputs.config_flag }}

--- a/pre-commit-action/no-unicode-check.py
+++ b/pre-commit-action/no-unicode-check.py
@@ -10,6 +10,10 @@
 # terms of the Apache License Version 2.0 which is available at
 # https://www.apache.org/licenses/LICENSE-2.0
 
+# /// script
+# dependencies = []
+# ///
+
 import argparse
 import sys
 

--- a/pre-commit-action/reuse-annotate-hook.py
+++ b/pre-commit-action/reuse-annotate-hook.py
@@ -27,15 +27,11 @@ Then runs reuse annotate to add/update the header (including template text).
 Comment style mapping is read from .reuse/styles.toml (downloaded or
 committed by the consumer repo).  Every file type that needs a header
 must be declared there; unmatched files will cause reuse annotate to error.
-
-Configurable via env vars (with defaults):
-  REUSE_COPYRIGHT  - copyright holder text
-  REUSE_LICENSE    - SPDX license identifier
-  REUSE_TEMPLATE   - name of .reuse/templates/<name>.jinja2
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import subprocess
@@ -190,15 +186,29 @@ def should_ignore(filepath: str, ignore_patterns: list[str]) -> bool:
 
 
 def main() -> int:
-    copyright_text = os.environ.get("REUSE_COPYRIGHT", DEFAULT_COPYRIGHT)
-    license_id = os.environ.get("REUSE_LICENSE", DEFAULT_LICENSE)
-    template = os.environ.get("REUSE_TEMPLATE", DEFAULT_TEMPLATE)
-    ignore_paths_str = os.environ.get("REUSE_IGNORE_PATHS", DEFAULT_IGNORE_PATHS)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--copyright", default=os.environ.get("REUSE_COPYRIGHT", DEFAULT_COPYRIGHT)
+    )
+    parser.add_argument(
+        "--license", default=os.environ.get("REUSE_LICENSE", DEFAULT_LICENSE)
+    )
+    parser.add_argument(
+        "--template", default=os.environ.get("REUSE_TEMPLATE", DEFAULT_TEMPLATE)
+    )
+    parser.add_argument(
+        "--ignore-paths",
+        default=os.environ.get("REUSE_IGNORE_PATHS", DEFAULT_IGNORE_PATHS),
+    )
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
 
-    # Parse ignore patterns from comma-separated string
-    ignore_patterns = [p.strip() for p in ignore_paths_str.split(",") if p.strip()]
+    copyright_text = args.copyright
+    license_id = args.license
+    template = args.template
+    ignore_patterns = [p.strip() for p in args.ignore_paths.split(",") if p.strip()]
 
-    files = sys.argv[1:]
+    files = args.files
     if not files:
         return 0
 

--- a/pre-commit-action/reuse-annotate-hook.py
+++ b/pre-commit-action/reuse-annotate-hook.py
@@ -185,21 +185,54 @@ def should_ignore(filepath: str, ignore_patterns: list[str]) -> bool:
     return False
 
 
+def is_git_new_file(filepath: str) -> bool:
+    """Return True if the file is newly added (not yet in HEAD)."""
+    result = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", filepath],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return True
+    result2 = subprocess.run(
+        ["git", "show", f"HEAD:{filepath}"],
+        capture_output=True,
+    )
+    return result2.returncode != 0
+
+
+def check_copyright_year_for_new_file(filepath: str) -> bool:
+    """Fail if a new file's SPDX-FileCopyrightText year is not the current year.
+
+    Returns True when the year is valid (or the file has no SPDX header yet).
+    Returns False and prints an error when the year is wrong.
+    """
+    try:
+        content = Path(filepath).read_text(errors="replace")
+    except OSError:
+        return True
+
+    match = re.search(r"SPDX-FileCopyrightText.*?(\d{4})", content)
+    if not match:
+        return True
+
+    year_in_file = match.group(1)
+    current = _current_year()
+    if year_in_file != current:
+        print(
+            f"{filepath}: new file has copyright year {year_in_file}, "
+            f"expected {current}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--copyright", default=os.environ.get("REUSE_COPYRIGHT", DEFAULT_COPYRIGHT)
-    )
-    parser.add_argument(
-        "--license", default=os.environ.get("REUSE_LICENSE", DEFAULT_LICENSE)
-    )
-    parser.add_argument(
-        "--template", default=os.environ.get("REUSE_TEMPLATE", DEFAULT_TEMPLATE)
-    )
-    parser.add_argument(
-        "--ignore-paths",
-        default=os.environ.get("REUSE_IGNORE_PATHS", DEFAULT_IGNORE_PATHS),
-    )
+    parser.add_argument("--copyright", default=DEFAULT_COPYRIGHT)
+    parser.add_argument("--license", default=DEFAULT_LICENSE)
+    parser.add_argument("--template", default=DEFAULT_TEMPLATE)
+    parser.add_argument("--ignore-paths", default=DEFAULT_IGNORE_PATHS)
     parser.add_argument("files", nargs="*")
     args = parser.parse_args()
 
@@ -211,6 +244,8 @@ def main() -> int:
     files = args.files
     if not files:
         return 0
+
+    failed = False
 
     # Template flag
     tpl_flag: list[str] = []
@@ -233,6 +268,8 @@ def main() -> int:
         # This avoids overwriting existing (possibly different but valid)
         # license/copyright information with the template.
         if has_valid_spdx_header(filepath):
+            if is_git_new_file(filepath) and not check_copyright_year_for_new_file(filepath):
+                failed = True
             continue
 
         # Resolve comment style
@@ -259,7 +296,7 @@ def main() -> int:
         ]
         subprocess.run(cmd, check=False)
 
-    return 0
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/run_checks.py
+++ b/run_checks.py
@@ -11,31 +11,23 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 
 # /// script
-# dependencies = ["pre-commit==4.2"]
+# dependencies = ["pre-commit==4.2", "PyYAML>=6"]
 # ///
 
 import argparse
-import os
 import subprocess
 import sys
-import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-# Default to 'main' branch, but can be overridden via environment variable or argument
+import yaml
+
 DEFAULT_BRANCH = "main"
-DEFAULT_COPYRIGHT = "The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)"
-DEFAULT_LICENSE = "Apache-2.0"
-DEFAULT_TEMPLATE = "opensovd"
 REPO_BASE_URL = (
     "https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/{branch}"
 )
 CONFIG_URL_TEMPLATE = f"{REPO_BASE_URL}/pre-commit-action/.pre-commit-config.yml"
-HOOK_SCRIPT_URL_TEMPLATE = f"{REPO_BASE_URL}/pre-commit-action/reuse-annotate-hook.py"
-NO_UNICODE_CHECK_SCRIPT_URL_TEMPLATE = (
-    f"{REPO_BASE_URL}/pre-commit-action/no-unicode-check.py"
-)
 TEMPLATE_URL_TEMPLATE = f"{REPO_BASE_URL}/.reuse/templates/{{template}}.jinja2"
 LICENSE_URL_TEMPLATE = f"{REPO_BASE_URL}/LICENSES/{{license}}.txt"
 REUSE_TOML_URL_TEMPLATE = f"{REPO_BASE_URL}/REUSE.toml"
@@ -46,95 +38,40 @@ CLIPPY_LINTS_CHECK_SCRIPT_URL_TEMPLATE = (
 )
 
 
-def patch_config(
-    config_content, *, fix_mode, no_unicode_extensions="", allowed_unicode_chars=""
-):
-    """Patch the pre-commit config for fix mode vs check-only mode.
-
-    In fix mode (local), ruff auto-fixes issues in place.
-    In check-only mode (CI), ruff reports issues without modifying files.
-    """
-    if fix_mode:
-        # ruff-check: add --fix
-        config_content = config_content.replace(
-            "args: [--output-format=full]",
-            "args: [--fix, --output-format=full]",
-        )
-        # ruff-format: remove --diff so it formats in place
-        config_content = config_content.replace(
-            "args: [--diff]",
-            "args: []",
-        )
-        # remove --check from cargo fmt entries so they format in place
-        config_content = config_content.replace(
-            "cargo fmt --check",
-            "cargo fmt",
-        )
-
-    if no_unicode_extensions:
-        parts = [
-            e.strip().lstrip(".")
-            for e in no_unicode_extensions.split(",")
-            if e.strip().lstrip(".")
-        ]
-        if parts:
-            files_regex = r"\.(" + "|".join(parts) + r")$"
-            entry = "python no-unicode-check.py"
-            if allowed_unicode_chars:
-                entry += f" --allowed-chars={allowed_unicode_chars}"
-            hook_block = (
-                "      - id: no-unicode-check\n"
-                "        name: No Unicode characters allowed\n"
-                f"        entry: {entry}\n"
-                "        language: system\n"
-                f"        files: '{files_regex}'\n"
-                "        pass_filenames: true\n"
-            )
-            config_content = config_content.rstrip("\n") + "\n" + hook_block
-
-    return config_content
+DEFAULT_LICENSE = "Apache-2.0"
+DEFAULT_TEMPLATE = "opensovd"
 
 
-def patch_hook_script(
-    script_content, *, copyright_text, license_id, template, ignore_paths, fix_mode
-):
-    """Patch the reuse-annotate hook script with configured values.
+def extract_reuse_args_from_config(config_path):
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception:
+        return DEFAULT_LICENSE, DEFAULT_TEMPLATE
 
-    Replaces the Python default constants so the script uses the provided
-    values directly, without depending on environment variables at runtime.
-    """
-    script_content = script_content.replace(
-        'DEFAULT_COPYRIGHT = "The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)"',
-        f'DEFAULT_COPYRIGHT = "{copyright_text}"',
-    )
-    script_content = script_content.replace(
-        'DEFAULT_LICENSE = "Apache-2.0"',
-        f'DEFAULT_LICENSE = "{license_id}"',
-    )
-    script_content = script_content.replace(
-        'DEFAULT_TEMPLATE = "opensovd"',
-        f'DEFAULT_TEMPLATE = "{template}"',
-    )
-    script_content = script_content.replace(
-        'DEFAULT_IGNORE_PATHS = ""',
-        f'DEFAULT_IGNORE_PATHS = "{ignore_paths}"',
-    )
+    for repo in config.get("repos", []):
+        for hook in repo.get("hooks", []):
+            if hook.get("id") == "reuse-annotate":
+                args = hook.get("args", [])
+                license_id = DEFAULT_LICENSE
+                template = DEFAULT_TEMPLATE
+                for arg in args:
+                    if arg.startswith("--license="):
+                        license_id = arg.split("=", 1)[1]
+                    elif arg.startswith("--template="):
+                        template = arg.split("=", 1)[1]
+                return license_id, template
 
-    return script_content
+    return DEFAULT_LICENSE, DEFAULT_TEMPLATE
 
 
 def download_if_missing(local_path, url, description):
-    """Download a file from url into local_path if it doesn't already exist.
-
-    Returns cleanup info (file path + created directories) or None if skipped.
-    """
     local_path = Path(local_path)
     if local_path.exists():
         return None
 
     print(f"Downloading {description} from: {url}")
 
-    # Track which directories we need to create so we can clean them up
     created_dirs = []
     check = local_path.parent
     while check != Path("."):
@@ -158,17 +95,15 @@ def download_if_missing(local_path, url, description):
 
 
 def cleanup_downloads(cleanup_list):
-    """Remove downloaded files and any directories we created."""
     for cleanup_info in cleanup_list:
         if cleanup_info is None:
             continue
         cleanup_info["file"].unlink(missing_ok=True)
-        # Remove directories we created, deepest first
         for d in reversed(cleanup_info["dirs"]):
             try:
                 d.rmdir()
             except OSError:
-                pass  # Directory not empty or already removed
+                pass
 
 
 def main():
@@ -182,233 +117,75 @@ def main():
         help="Git branch to use for downloading configs (default: main)",
     )
     parser.add_argument(
-        "--copyright",
-        default=DEFAULT_COPYRIGHT,
-        help=f"Copyright holder text for reuse annotate (default: {DEFAULT_COPYRIGHT})",
-    )
-    parser.add_argument(
-        "--license",
-        default=DEFAULT_LICENSE,
-        help=f"SPDX license identifier for reuse annotate (default: {DEFAULT_LICENSE})",
-    )
-    parser.add_argument(
-        "--template",
-        default=DEFAULT_TEMPLATE,
-        help=f"Name of reuse Jinja2 template in .reuse/templates/ (default: {DEFAULT_TEMPLATE})",
-    )
-    parser.add_argument(
         "--config",
         default=None,
         help="Path to a local .pre-commit-config.yml (skips downloading from remote)",
     )
-    parser.add_argument(
-        "--hook-script",
-        default=None,
-        help="Path to a local reuse-annotate-hook.py (skips downloading from remote)",
-    )
-    parser.add_argument(
-        "--no-unicode-check-script",
-        default=None,
-        help="Path to a local no-unicode-check.py (skips downloading from remote)",
-    )
-    parser.add_argument(
-        "--no-fix",
-        action="store_true",
-        help="Run in check-only mode (no auto-fix). Used in CI to report issues without modifying files.",
-    )
-    parser.add_argument(
-        "--ignore-paths",
-        default="",
-        help="Comma-separated list of file patterns to ignore during REUSE checks (e.g., '*.md,docs/**,*.txt')",
-    )
-    parser.add_argument(
-        "--no-unicode-extensions",
-        default="",
-        help="Comma-separated file extensions to check for non-ASCII characters (e.g., '.py,.rs'). Empty string disables the check.",
-    )
-    parser.add_argument(
-        "--allowed-unicode-chars",
-        default="",
-        help="Comma-separated Unicode characters to allow in the no-unicode check (e.g., '\u00b5,\u00a7'). Empty by default.",
-    )
 
     args = parser.parse_args()
-
-    # Treat empty strings as unset (GitHub Actions passes "" for unset inputs)
-    if not args.copyright:
-        args.copyright = DEFAULT_COPYRIGHT
-    if not args.license:
-        args.license = DEFAULT_LICENSE
-    if not args.template:
-        args.template = DEFAULT_TEMPLATE
-
     branch = args.branch
     cleanup_list = []
-    config_path = args.config
-    config_is_temp = False
 
     try:
-        # Resolve pre-commit config: use local or download from remote
-        fix_mode = not args.no_fix
-
+        config_path = args.config
         if config_path is None:
             config_url = CONFIG_URL_TEMPLATE.format(branch=branch)
             print(f"Downloading pre-commit config from: {config_url}")
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".yml", delete=False
-            ) as f:
-                with urllib.request.urlopen(config_url) as response:
-                    config_content = response.read().decode()
-                config_content = patch_config(
-                    config_content,
-                    fix_mode=fix_mode,
-                    no_unicode_extensions=args.no_unicode_extensions,
-                    allowed_unicode_chars=args.allowed_unicode_chars,
-                )
-                f.write(config_content)
-                config_path = f.name
-            config_is_temp = True
-        else:
-            # Local config provided: always patch a temp copy to inject settings
-            config_content = Path(config_path).read_text()
-            config_content = patch_config(
-                config_content,
-                fix_mode=fix_mode,
-                no_unicode_extensions=args.no_unicode_extensions,
-                allowed_unicode_chars=args.allowed_unicode_chars,
-            )
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".yml", delete=False
-            ) as f:
-                f.write(config_content)
-                config_path = f.name
-            config_is_temp = True
+            config_tmp = Path(".pre-commit-config-remote.yml")
+            with urllib.request.urlopen(config_url) as response:
+                config_tmp.write_text(response.read().decode())
+            cleanup_list.append({"file": config_tmp, "dirs": []})
+            config_path = str(config_tmp)
 
-        # Resolve hook script: use local (--hook-script), CWD, or download.
-        # The script must end up at ./reuse-annotate-hook.py (CWD) because
-        # the pre-commit config entry is: python3 reuse-annotate-hook.py
-        hook_cwd_path = Path("reuse-annotate-hook.py")
-        hook_existed_in_cwd = hook_cwd_path.exists()
+        license_id, template = extract_reuse_args_from_config(config_path)
 
-        if args.hook_script:
-            # Explicit path provided (e.g. from GitHub Action)
-            script_content = Path(args.hook_script).read_text()
-        elif hook_existed_in_cwd:
-            # Already in CWD (e.g. running inside this repo)
-            script_content = hook_cwd_path.read_text()
-        else:
-            # Download from remote
-            hook_url = HOOK_SCRIPT_URL_TEMPLATE.format(branch=branch)
-            print(f"Downloading reuse-annotate hook script from: {hook_url}")
-            with urllib.request.urlopen(hook_url) as response:
-                script_content = response.read().decode()
-
-        # Patch default constants with configured values and write to CWD
-        patched = patch_hook_script(
-            script_content,
-            copyright_text=args.copyright,
-            license_id=args.license,
-            template=args.template,
-            ignore_paths=args.ignore_paths,
-            fix_mode=fix_mode,
-        )
-
-        hook_cwd_path.write_text(patched)
-
-        # Clean up if we created the file (downloaded or copied from elsewhere)
-        if not hook_existed_in_cwd:
-            cleanup_list.append({"file": hook_cwd_path, "dirs": []})
-
-        # Ensure no-unicode-check.py is in CWD when the feature is enabled so
-        # the pre-commit entry 'python no-unicode-check.py' resolves correctly.
-        if args.no_unicode_extensions:
-            no_unicode_cwd_path = Path("no-unicode-check.py")
-            no_unicode_existed_in_cwd = no_unicode_cwd_path.exists()
-
-            if args.no_unicode_check_script:
-                no_unicode_cwd_path.write_text(
-                    Path(args.no_unicode_check_script).read_text()
-                )
-            elif not no_unicode_existed_in_cwd:
-                cleanup_list.append(
-                    download_if_missing(
-                        no_unicode_cwd_path,
-                        NO_UNICODE_CHECK_SCRIPT_URL_TEMPLATE.format(branch=branch),
-                        "no-unicode-check script",
-                    )
-                )
-
-            if args.no_unicode_check_script and not no_unicode_existed_in_cwd:
-                cleanup_list.append({"file": no_unicode_cwd_path, "dirs": []})
-
-        # Ensure REUSE assets are available locally
-        reuse_toml_url = REUSE_TOML_URL_TEMPLATE.format(branch=branch)
         cleanup_list.append(
             download_if_missing(
                 "REUSE.toml",
-                reuse_toml_url,
+                REUSE_TOML_URL_TEMPLATE.format(branch=branch),
                 "REUSE.toml",
             )
         )
-
-        template_url = TEMPLATE_URL_TEMPLATE.format(
-            branch=branch, template=args.template
+        cleanup_list.append(
+            download_if_missing(
+                f".reuse/templates/{template}.jinja2",
+                TEMPLATE_URL_TEMPLATE.format(branch=branch, template=template),
+                f"reuse template '{template}'",
+            )
         )
         cleanup_list.append(
             download_if_missing(
-                f".reuse/templates/{args.template}.jinja2",
-                template_url,
-                f"reuse template '{args.template}'",
+                f"LICENSES/{license_id}.txt",
+                LICENSE_URL_TEMPLATE.format(branch=branch, license=license_id),
+                f"license text '{license_id}'",
             )
         )
-
-        license_url = LICENSE_URL_TEMPLATE.format(branch=branch, license=args.license)
-        cleanup_list.append(
-            download_if_missing(
-                f"LICENSES/{args.license}.txt",
-                license_url,
-                f"license text '{args.license}'",
-            )
-        )
-
-        styles_url = STYLES_URL_TEMPLATE.format(branch=branch)
         cleanup_list.append(
             download_if_missing(
                 ".reuse/styles.toml",
-                styles_url,
+                STYLES_URL_TEMPLATE.format(branch=branch),
                 "reuse comment styles config",
             )
         )
-
-        clippy_lints_url = CLIPPY_LINTS_URL_TEMPLATE.format(branch=branch)
         cleanup_list.append(
             download_if_missing(
                 "shared-lints/shared-lints.toml",
-                clippy_lints_url,
+                CLIPPY_LINTS_URL_TEMPLATE.format(branch=branch),
                 "Clippy lints config",
             )
-        )
-        clippy_lints_check_script_url = CLIPPY_LINTS_CHECK_SCRIPT_URL_TEMPLATE.format(
-            branch=branch
         )
         cleanup_list.append(
             download_if_missing(
                 "shared-lints/check_cargo_lints.py",
-                clippy_lints_check_script_url,
+                CLIPPY_LINTS_CHECK_SCRIPT_URL_TEMPLATE.format(branch=branch),
                 "Clippy lints check script",
             )
         )
-
-        if not fix_mode:
-            env = {**os.environ, "SKIP": "reuse-annotate"}
-        else:
-            env = None
 
         print("Running pre-commit checks...")
         result = subprocess.run(
             ["pre-commit", "run", "--all-files", "--config", config_path],
             check=False,
-            env=env,
         )
         sys.exit(result.returncode)
     except urllib.error.HTTPError as e:
@@ -419,10 +196,7 @@ def main():
         )
         sys.exit(1)
     except urllib.error.URLError as e:
-        print(
-            f"Network error: {e.reason}",
-            file=sys.stderr,
-        )
+        print(f"Network error: {e.reason}", file=sys.stderr)
         print(
             "Could not reach GitHub. Please check your internet connection and try again.",
             file=sys.stderr,
@@ -432,8 +206,6 @@ def main():
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     finally:
-        if config_is_temp and config_path:
-            Path(config_path).unlink(missing_ok=True)
         cleanup_downloads(cleanup_list)
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- Fixes a gap in the `reuse-annotate-hook.py` where a newly added file that already carries an `SPDX-FileCopyrightText` header with a stale year was silently accepted
- Adds `is_git_new_file()` to detect files not yet present in HEAD (via `git ls-files` + `git show HEAD:<path>`)
- Adds `check_copyright_year_for_new_file()` to validate the year in the header matches the current year, failing with a clear error if not
- Existing files are unaffected — only new files with a pre-written wrong year are rejected
- Not configurable by design; the current year is the only correct value for a brand-new file

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

<!-- List any related issues or PRs (e.g. Fixes #12 or Closes #34). -->

## Notes for Reviewers

<!-- Optional: Add anything that may help reviewers understand this PR faster. -->

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)