### PR TITLE
feat: add optional PR comment posting to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,9 +33,19 @@ on:
         description: "Regex for filenames to ignore in coverage"
         type: string
         default: ""
+      cargo-extra-args:
+        description: "Extra arguments appended to every cargo llvm-cov invocation (e.g. '--features integration-tests')"
+        type: string
+        default: ""
+      post-pr-comment:
+        description: "Post or update a sticky coverage comment on the PR (requires pull-requests: write permission in the caller)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  # pull-requests: write is required when post-pr-comment input is true.
+  # The caller workflow must grant this permission explicitly.
 
 jobs:
   coverage:
@@ -66,11 +76,12 @@ jobs:
           done
           echo "locked=$LOCKED" >> "$GITHUB_OUTPUT"
           echo "excludes=$EXCLUDES" >> "$GITHUB_OUTPUT"
+          echo "extra=${{ inputs.cargo-extra-args }}" >> "$GITHUB_OUTPUT"
 
       - name: Generate coverage (LCOV)
         shell: bash
         run: |
-          ARGS=(--workspace ${{ steps.flags.outputs.locked }} ${{ steps.flags.outputs.excludes }})
+          ARGS=(--workspace ${{ steps.flags.outputs.locked }} ${{ steps.flags.outputs.excludes }} ${{ steps.flags.outputs.extra }})
           if [ -n "$IGNORE_REGEX" ]; then
             ARGS+=(--ignore-filename-regex "$IGNORE_REGEX")
           fi
@@ -80,7 +91,7 @@ jobs:
         id: coverage
         shell: bash
         run: |
-          ARGS=(--workspace ${{ steps.flags.outputs.locked }} ${{ steps.flags.outputs.excludes }})
+          ARGS=(--workspace ${{ steps.flags.outputs.locked }} ${{ steps.flags.outputs.excludes }} ${{ steps.flags.outputs.extra }})
           if [ -n "$IGNORE_REGEX" ]; then
             ARGS+=(--ignore-filename-regex "$IGNORE_REGEX")
           fi
@@ -119,3 +130,42 @@ jobs:
             exit 1
           fi
           echo "Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
+
+      - name: Post coverage comment on PR
+        if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- coverage-report -->';
+            const total = '${{ steps.coverage.outputs.total_coverage }}';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              marker,
+              '### \uD83D\uDCCA Coverage Report',
+              '',
+              `**Total line coverage: ${total}%**`,
+              '',
+              `[Full build artifacts](${runUrl})`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- Adds a `post-pr-comment` boolean input to the reusable `coverage.yml` workflow (default: `false`)
- When enabled, posts or updates a sticky coverage comment on the triggering PR using an HTML marker (`<!-- coverage-report -->`) to avoid duplicate comments
- Callers must grant `pull-requests: write` in their own workflow permissions when opting into this feature

## Usage

```yaml
jobs:
  coverage:
    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@main
    with:
      post-pr-comment: true
    permissions:
      contents: read
      pull-requests: write
```

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests