### PR TITLE
feat: add first-interaction workflow for new contributors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,7 @@ jobs:
     env:
       IGNORE_REGEX: ${{ inputs.ignore-filename-regex }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -113,7 +113,7 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,16 +39,14 @@ on:
         type: string
         default: ""
       post-pr-comment:
-        description: >-
-          Generate a coverage PR comment and upload it as the 'pr-comment-coverage' artifact. For non-fork PRs the comment is also posted directly (requires pull-requests: write in the caller). Fork PRs can be handled by a workflow_run workflow that calls post-pr-comments.yml.
+        description: "Post or update a sticky coverage comment on the PR (requires pull-requests: write permission in the caller)"
         type: boolean
         default: false
 
 permissions:
   contents: read
   # pull-requests: write is required when post-pr-comment input is true.
-  # The caller workflow must grant this permission explicitly.
-  pull-requests: write
+# The caller workflow must grant this permission explicitly.
 
 jobs:
   coverage:
@@ -57,7 +55,7 @@ jobs:
     env:
       IGNORE_REGEX: ${{ inputs.ignore-filename-regex }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -115,7 +113,7 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov
           path: lcov.info
@@ -134,45 +132,22 @@ jobs:
           fi
           echo "Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
 
-      - name: Generate coverage comment body
-        if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
-        shell: bash
-        run: |
-          mkdir -p pr-comment-coverage
-          echo "${{ github.event.number }}" > pr-comment-coverage/pr_number
-          MARKER='<!-- coverage-report -->'
-          TOTAL='${{ steps.coverage.outputs.total_coverage }}'
-          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          SYMBOL="$(printf '\xf0\x9f\x93\x8a')"
-          printf '%s\n' \
-            "${MARKER}" \
-            "### ${SYMBOL} Coverage Report" \
-            '' \
-            "**Total line coverage: ${TOTAL}%**" \
-            '' \
-            "[Full build artifacts](${RUN_URL})" \
-            > pr-comment-coverage/body.md
-
-      - name: Upload coverage comment artifact
-        if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr-comment-coverage
-          path: pr-comment-coverage/
-
-      # Post directly for non-fork PRs (instant feedback).
-      # Fork PRs lack write permissions and cannot directly post comments.
-      # they can be handled by a separate workflow_run workflow that calls
-      # post-pr-comments.yml.
       - name: Post coverage comment on PR
-        if: >-
-          inputs.post-pr-comment && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v9
+        if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('pr-comment-coverage/body.md', 'utf8');
             const marker = '<!-- coverage-report -->';
+            const total = '${{ steps.coverage.outputs.total_coverage }}';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              marker,
+              '### \uD83D\uDCCA Coverage Report',
+              '',
+              `**Total line coverage: ${total}%**`,
+              '',
+              `[Full build artifacts](${runUrl})`,
+            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -29,7 +29,7 @@ jobs:
           issue-message: |
             Welcome, and thanks for opening your first issue!
 
-            Please make sure you've reviewed our [contribution guidelines](https://github.com/eclipse-opensovd/opensovd/blob/main/CONTRIBUTING.md)
+            Please make sure you've reviewed our [contribution guidelines](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/blob/main/CONTRIBUTING.md)
             and that your issue includes enough context for maintainers to understand the problem.
 
             The team will get back to you as soon as possible.

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   first-interaction:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,5 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -7,6 +6,8 @@
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at
 # https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
 
 name: First Interaction
 

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: First Interaction
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  first-interaction:
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Welcome, and thanks for opening your first issue!
+
+            Please make sure you've reviewed our [contribution guidelines](https://github.com/eclipse-opensovd/opensovd/blob/main/CONTRIBUTING.md)
+            and that your issue includes enough context for maintainers to understand the problem.
+
+            The team will get back to you as soon as possible.
+          pr-message: |
+            Thanks for your first pull request!
+
+            A few things to keep in mind:
+            - Make sure CI checks pass before requesting a review.
+            - Eclipse projects require a **DCO sign-off** on every commit:
+              use `git commit -s` or add `Signed-off-by: Your Name <email>` manually.
+            - See [CONTRIBUTING.md](https://github.com/eclipse-opensovd/opensovd/blob/main/CONTRIBUTING.md) for details.
+
+            A maintainer will review your PR shortly. Welcome to the project!


### PR DESCRIPTION
## Summary

Adds a `first-interaction.yml` workflow that automatically posts a
welcome comment when someone opens their first issue or pull request
in the repository.

## Motivation

Identified as a gap in issue #38 (CI parity analysis: opensovd-core
vs cicd-workflows). The `opensovd-core` repository already has this
workflow; this change brings `cicd-workflows` to parity.

## Changes

- Added `.github/workflows/first-interaction.yml` using
  `actions/first-interaction@v1`
- Posts a welcome message on first issues reminding contributors to
  follow the contribution guidelines
- Posts a welcome message on first PRs reminding contributors about
  CI checks and the Eclipse DCO sign-off requirement

## Testing

- Ran `uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py` locally — all checks passed
- Workflow syntax validated by `check yaml` and `yamlfmt` hooks

Relates to #38