### PR TITLE
coverage: split out PR comment posting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,8 @@ on:
         type: string
         default: ""
       post-pr-comment:
-        description: "Post or update a sticky coverage comment on the PR (requires pull-requests: write permission in the caller)"
+        description: >-
+          Generate a coverage PR comment and upload it as the 'pr-comment-coverage' artifact. For non-fork PRs the comment is also posted directly (requires pull-requests: write in the caller). Fork PRs can be handled by a workflow_run workflow that calls post-pr-comments.yml.
         type: boolean
         default: false
 
@@ -132,22 +133,44 @@ jobs:
           fi
           echo "Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
 
-      - name: Post coverage comment on PR
+      - name: Generate coverage comment body
         if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          mkdir -p pr-comment-coverage
+          echo "${{ github.event.number }}" > pr-comment-coverage/pr_number
+          MARKER='<!-- coverage-report -->'
+          TOTAL='${{ steps.coverage.outputs.total_coverage }}'
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          printf '%s\n' \
+            "${MARKER}" \
+            '### \uD83D\uDCCA Coverage Report' \
+            '' \
+            "**Total line coverage: ${TOTAL}%**" \
+            '' \
+            "[Full build artifacts](${RUN_URL})" \
+            > pr-comment-coverage/body.md
+
+      - name: Upload coverage comment artifact
+        if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment-coverage
+          path: pr-comment-coverage/
+
+      # Post directly for non-fork PRs (instant feedback).
+      # Fork PRs lack write permissions and cannot directly post comments.
+      # they can be handled by a separate workflow_run workflow that calls
+      # post-pr-comments.yml.
+      - name: Post coverage comment on PR
+        if: >-
+          inputs.post-pr-comment && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('pr-comment-coverage/body.md', 'utf8');
             const marker = '<!-- coverage-report -->';
-            const total = '${{ steps.coverage.outputs.total_coverage }}';
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              marker,
-              '### \uD83D\uDCCA Coverage Report',
-              '',
-              `**Total line coverage: ${total}%**`,
-              '',
-              `[Full build artifacts](${runUrl})`,
-            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/post-pr-comments.yml
+++ b/.github/workflows/post-pr-comments.yml
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+# Post PR comments from artifacts produced by other reusable workflows
+# (e.g. coverage.yml, crap.yml).
+#
+# This workflow is intended to be called from a workflow_run trigger in the
+# consuming repository so that comments can be posted even on fork PRs, where
+# the GITHUB_TOKEN from the pull_request event is read-only.
+#
+# Artifact convention:
+#   Each comment-producing workflow uploads an artifact named
+#   "pr-comment-<name>" containing two files:
+#     - pr_number   : plain text file with the PR number
+#     - body.md     : the full comment markdown; the first line must be an
+#                     HTML comment used as a unique marker (e.g.
+#                     "<!-- coverage-report -->")
+#
+# Example caller (in the consuming repo):
+#
+#   name: Post PR Comments
+#   on:
+#     workflow_run:
+#       workflows: ["Rust CI"]
+#       types: [completed]
+#   jobs:
+#     post:
+#       if: github.event.workflow_run.event == 'pull_request'
+#       uses: eclipse-opensovd/cicd-workflows/.github/workflows/post-pr-comments.yml@main
+#       with:
+#         run-id: ${{ github.event.workflow_run.id }}
+#       permissions:
+#         pull-requests: write
+
+name: Post PR Comments
+
+on:
+  workflow_call:
+    inputs:
+      run-id:
+        description: "Workflow run ID to download comment artifacts from"
+        required: true
+        type: string
+      comment-artifacts:
+        description: "Space-separated list of artifact names to look for and post as PR comments"
+        type: string
+        default: "pr-comment-coverage"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  post-comments:
+    name: Post PR Comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download comment artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          for name in ${{ inputs.comment-artifacts }}; do
+            echo "Downloading artifact: ${name}"
+            if gh run download "${{ inputs.run-id }}" --name "${name}" --dir "${name}"; then
+              echo "  -> downloaded successfully"
+            else
+              echo "  -> not found or download failed, skipping"
+            fi
+          done
+
+      - name: Post PR comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const artifacts = '${{ inputs.comment-artifacts }}'
+              .split(/\s+/)
+              .filter(Boolean);
+
+            for (const name of artifacts) {
+              const bodyPath = path.join(name, 'body.md');
+              const prPath = path.join(name, 'pr_number');
+
+              if (!fs.existsSync(bodyPath) || !fs.existsSync(prPath)) {
+                console.log(`Skipping '${name}': artifact files not found.`);
+                continue;
+              }
+
+              const body = fs.readFileSync(bodyPath, 'utf8');
+              const prNumber = parseInt(fs.readFileSync(prPath, 'utf8').trim(), 10);
+              const marker = body.split('\n')[0];
+
+              console.log(`Processing '${name}' for PR #${prNumber} (marker: ${marker})`);
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+              const existing = comments.find(c => c.body.includes(marker));
+
+              if (existing) {
+                if (existing.body.trim() === body.trim()) {
+                  console.log(`  -> comment already up to date, skipping.`);
+                  continue;
+                }
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                console.log(`  -> comment updated.`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+                console.log(`  -> comment created.`);
+              }
+            }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Split posting of PR comment into a standalone workflow that can use the artifacts created by the coverage.yml action to post a comment on a PR via workflow_call. This allows for comments to be posted on PRs originating from forks.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)