### PR TITLE
cicd: Enable string_slice Clippy lint

### DIFF
--- a/shared-lints/shared-lints.toml
+++ b/shared-lints/shared-lints.toml
@@ -23,6 +23,10 @@ unwrap_used = "deny"
 # either checked or explicit versions of the operations. eg. `.checked_add(...)`
 # or `.saturating_sub(...)` to avoid unexpected runtime behavior or panics.
 arithmetic_side_effects = "deny"
+# disallow direct byte/range slicing of `&str` (e.g. `s[..n]`) which can panic
+# when a range falls inside a multi-byte UTF-8 codepoint. Prefer
+# `s.get(..n)`, `s.split_at_checked(...)`, or char-based iteration.
+string_slice = "deny"
 ## lints related to readability of code
 # enforce that references are cloned via eg. `Arc::clone` instead of `.clone()`
 # making it explit that a reference is cloned here and not the underlying data.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->
## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Enable string_slice Clippy lint to disallow direct byte/range slicing of `&str` (e.g. `s[..n]`) which can panic when a range falls inside a multi-byte UTF-8 codepoint.
## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

[Issue](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/pull/359#issuecomment-4638067033)
[Related Issue](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/333)

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
