### PR TITLE
fix: update actions versions to support node 24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
     name: Cargo Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -64,7 +64,7 @@ jobs:
     if: ${{ inputs.bazel-enabled }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.14.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       IGNORE_REGEX: ${{ inputs.ignore-filename-regex }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -114,7 +114,7 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: lcov.info
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload coverage comment artifact
         if: ${{ inputs.post-pr-comment && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-comment-coverage
           path: pr-comment-coverage/
@@ -166,7 +166,7 @@ jobs:
       - name: Post coverage comment on PR
         if: >-
           inputs.post-pr-comment && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       MIRIFLAGS: ${{ inputs.miri-flags }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/post-pr-comments.yml
+++ b/.github/workflows/post-pr-comments.yml
@@ -78,7 +78,7 @@ jobs:
           done
 
       - name: Post PR comments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -197,7 +197,7 @@ jobs:
 
       - name: Set up Node.js
         if: inputs.package-manager == 'npm'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm
@@ -233,7 +233,7 @@ jobs:
       contents: write
     steps:
       - name: Rename assets and generate latest.json
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           APP_BINARY_NAME: ${{ inputs.app-binary-name }}
         with:


### PR DESCRIPTION
## Summary
Since some jobs are using deprecated actions based on node 20, the versions of the corresponding actions are updated.

## Related
https://github.com/eclipse-opensovd/classic-diagnostic-adapter/pull/372

## Notes for Reviewers
Veronika Neumann [veronika.neumann@mercedes-benz.com](mailto:veronika.neumann@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)

