### PR TITLE
chore: pin all workflows to ubuntu-24.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   cargo-build-test:
     name: Cargo Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -62,7 +62,7 @@ jobs:
   bazel-build-test:
     name: Bazel Build & Test
     if: ${{ inputs.bazel-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,7 @@ permissions:
 jobs:
   coverage:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       IGNORE_REGEX: ${{ inputs.ignore-filename-regex }}
     steps:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   cargo-miri:
     name: Miri (Undefined Behavior Check)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       MIRIFLAGS: ${{ inputs.miri-flags }}
     steps:

--- a/.github/workflows/post-pr-comments.yml
+++ b/.github/workflows/post-pr-comments.yml
@@ -60,7 +60,7 @@ permissions:
 jobs:
   post-comments:
     name: Post PR Comments
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download comment artifacts
         env:

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -75,7 +75,7 @@ on:
         default: false
 
       build-linux:
-        description: "Include the Linux (ubuntu-latest) build (default: true)"
+        description: "Include the Linux (ubuntu-24.04) build (default: true)"
         type: boolean
         default: true
 
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-latest
+          - platform: ubuntu-24.04
             args: ""
             rust_targets: ""
             enabled: ${{ inputs.build-linux }}
@@ -177,7 +177,7 @@ jobs:
           targets: ${{ matrix.rust_targets }}
 
       - name: Install Linux system dependencies
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-24.04'
         shell: bash
         run: |
           sudo apt-get update
@@ -228,7 +228,7 @@ jobs:
   merge-updater-json:
     needs:
       - build-tauri
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Closes #55 
Pin all workflow runners to `ubuntu-24.04` instead of `ubuntu-latest` 
to ensure reproducible builds, as discussed in #42 


## Checklist
- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
-  [x] I have linked related issues or discussions
- [ ] I have added or updated tests
Files Updated
- .github/workflows/checks.yml
- .github/workflows/build-and-test.yml
- .github/workflows/coverage.yml
- .github/workflows/miri.yml
- .github/workflows/post-pr-comments.yml
- .github/workflows/tauri-release.yml

