### PR TITLE
fix: resolve invalid workflow expression errors in tauri-release.yml

### DIFF
--- a/.github/actions/inject-version/action.yml
+++ b/.github/actions/inject-version/action.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+name: Inject version from tag
+description: >
+  Strips pre-release/build-metadata suffixes from the tag (e.g. v0.2.2-rc.1 -> 0.2.2) and writes the result into tauri.conf.json and Cargo.toml. The numeric-only form is required by the Windows MSI bundler and Cargo. #magic___^_^___line
+inputs:
+  tauri-conf-path:
+    description: "Relative path to tauri.conf.json"
+    required: true
+  cargo-toml-path:
+    description: "Relative path to Cargo.toml"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Inject version
+      shell: python3 {0}
+      env:
+        VERSION: ${{ github.ref_name }}
+        TAURI_CONF: ${{ inputs.tauri-conf-path }}
+        CARGO_TOML: ${{ inputs.cargo-toml-path }}
+      run: |
+        import json, os, re, sys
+
+        os.chdir(os.environ["GITHUB_WORKSPACE"])
+
+        raw = os.environ.get("VERSION") or os.environ.get("GITHUB_REF_NAME", "")
+        raw = raw.lstrip("v")
+        # Strip pre-release and build metadata (e.g. -rc.1) - required for MSI/Cargo compatibility
+        v = re.sub(r"[-+].*$", "", raw)
+
+        if not v:
+            print("ERROR: could not determine version from VERSION or GITHUB_REF_NAME", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Injecting version: {raw!r} -> {v!r}")
+
+        tauri_conf = os.environ["TAURI_CONF"]
+        cargo_toml = os.environ["CARGO_TOML"]
+
+        with open(tauri_conf) as f:
+            cfg = json.load(f)
+        cfg["version"] = v
+        with open(tauri_conf, "w") as f:
+            json.dump(cfg, f, indent=2)
+            f.write("\n")
+
+        with open(cargo_toml) as f:
+            text = f.read()
+        # Replace version only in [package] section (first occurrence)
+        text = re.sub(r'^version = "[^"]+"', f'version = "{v}"', text, count=1, flags=re.MULTILINE)
+        with open(cargo_toml, "w") as f:
+            f.write(text)

--- a/.github/actions/tauri-build-setup/action.yml
+++ b/.github/actions/tauri-build-setup/action.yml
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Tauri build setup
+description: >
+  Shared setup steps for every Tauri release build job: checkout, version injection, Rust toolchain, optional Linux system dependencies, and frontend tooling (Bun or npm). #magic___^_^___line
+inputs:
+  tauri-conf-path:
+    description: "Relative path to tauri.conf.json"
+    required: true
+  cargo-toml-path:
+    description: "Relative path to Cargo.toml"
+    required: true
+  rust-version:
+    description: "Rust toolchain version"
+    required: false
+    default: "stable"
+  rust-target:
+    description: "Additional Rust target to install (e.g. aarch64-apple-darwin). Leave empty to skip."
+    required: false
+    default: ""
+  install-linux-deps:
+    description: "Install Linux (apt-get) system dependencies required by Tauri. Set to 'true' on Ubuntu runners."
+    required: false
+    default: "false"
+  package-manager:
+    description: "Frontend package manager: 'bun' or 'npm'"
+    required: false
+    default: "bun"
+  bun-version:
+    description: "Bun version to install when package-manager is 'bun'"
+    required: false
+    default: "latest"
+  node-version:
+    description: "Node.js version to install when package-manager is 'npm'"
+    required: false
+    default: "22"
+  frontend-dir:
+    description: "Directory that contains package.json"
+    required: false
+    default: "frontend"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: false
+
+    - name: Inject version from tag
+      uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+      with:
+        tauri-conf-path: ${{ inputs.tauri-conf-path }}
+        cargo-toml-path: ${{ inputs.cargo-toml-path }}
+
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ inputs.rust-version }}
+        target: ${{ inputs.rust-target }}
+
+    - name: Install Linux system dependencies
+      if: inputs.install-linux-deps == 'true'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          build-essential \
+          libssl-dev \
+          libxdo-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev
+
+    - name: Set up Bun
+      if: inputs.package-manager == 'bun'
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Set up Node.js
+      if: inputs.package-manager == 'npm'
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - name: Install frontend dependencies (bun)
+      if: inputs.package-manager == 'bun'
+      shell: bash
+      run: bun install
+      working-directory: ${{ inputs.frontend-dir }}
+
+    - name: Install frontend dependencies (npm)
+      if: inputs.package-manager == 'npm'
+      shell: bash
+      run: npm ci
+      working-directory: ${{ inputs.frontend-dir }}

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -24,7 +24,8 @@ on:
         required: true
 
       app-binary-name:
-        description: "Binary name of the app, e.g. \"mdd-ui\". Used for asset renaming."
+        description: >
+          Binary name of the app, e.g. "mdd-ui". Required for asset renaming (adds OS/Ubuntu-version suffix to .deb and other bundle filenames). If omitted, the rename step will fail.
         type: string
         required: true
 
@@ -69,7 +70,8 @@ on:
         default: false
 
       prerelease:
-        description: "Mark release as a pre-release (default: false)"
+        description: >
+          Mark release as a pre-release (default: false). Tags containing '-rc', '-alpha', or '-beta' (e.g. v1.2.3-rc.1) are always treated as pre-releases regardless of this input.
         type: boolean
         default: false
 
@@ -117,62 +119,51 @@ permissions:
   contents: write
 
 jobs:
+  create-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-26.04
+    outputs:
+      release-id: ${{ steps.create.outputs.releaseId }}
+    steps:
+      - name: Create GitHub release
+        id: create
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const tagName = context.ref.replace('refs/tags/', '');
+            // A tag containing '-rc' (e.g. v1.2.3-rc.1) is always a pre-release,
+            // regardless of the caller-supplied input.
+            const isPrerelease = ${{ inputs.prerelease }} || /-(rc|alpha|beta)[.\d]*$/i.test(tagName);
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              tag_name: tagName,
+              name: "${{ inputs.app-name }} " + tagName,
+              draft: ${{ inputs.release-draft }},
+              prerelease: isPrerelease,
+              generate_release_notes: false,
+            });
+            core.setOutput('releaseId', String(release.id));
+
   build-ubuntu-24-04:
+    needs: create-release
     if: inputs.build-ubuntu-24-04 != false
     permissions:
       contents: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: false
-
-      - name: Inject version from tag
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+      - name: Set up Tauri build environment
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@fix-tauri-release
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ inputs.rust-version }}
-
-      - name: Install Linux system dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            libssl-dev \
-            libxdo-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
-
-      - name: Set up Bun
-        if: inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@v2
-        with:
+          rust-version: ${{ inputs.rust-version }}
+          install-linux-deps: "true"
+          package-manager: ${{ inputs.package-manager }}
           bun-version: ${{ inputs.bun-version }}
-
-      - name: Set up Node.js
-        if: inputs.package-manager == 'npm'
-        uses: actions/setup-node@v6
-        with:
           node-version: ${{ inputs.node-version }}
-          cache: npm
-
-      - name: Install frontend dependencies (bun)
-        if: inputs.package-manager == 'bun'
-        run: bun install
-        working-directory: ${{ inputs.frontend-dir }}
-
-      - name: Install frontend dependencies (npm)
-        if: inputs.package-manager == 'npm'
-        run: npm ci
-        working-directory: ${{ inputs.frontend-dir }}
+          frontend-dir: ${{ inputs.frontend-dir }}
 
       - name: Build and upload Tauri bundles
         uses: tauri-apps/tauri-action@v0
@@ -181,68 +172,54 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
-          releaseDraft: ${{ inputs.release-draft }}
-          prerelease: ${{ inputs.prerelease }}
-          args: ""
+          releaseId: ${{ needs.create-release.outputs.release-id }}
+          args: "--bundles deb"
+
+      - name: Rename deb asset to ubuntu2404 name
+        uses: actions/github-script@v9
+        env:
+          APP_BINARY_NAME: ${{ inputs.app-binary-name }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release-id }}
+        with:
+          script: |
+            const bin       = process.env.APP_BINARY_NAME;
+            const releaseId = parseInt(process.env.RELEASE_ID, 10);
+            const owner     = context.repo.owner;
+            const repo      = context.repo.repo;
+            const { data: assets } = await github.rest.repos.listReleaseAssets({
+              owner, repo, release_id: releaseId, per_page: 100,
+            });
+            const re = new RegExp(`^${bin}_([\\d.]+)_amd64\\.deb$`, 'i');
+            const deb = assets.find(a => re.test(a.name));
+            if (!deb) { core.setFailed('ubuntu-24.04 .deb asset not found'); return; }
+            const version = deb.name.match(re)[1];
+            const newName = `${bin}_${version}_linux_ubuntu2404_amd64.deb`;
+            await github.rest.repos.updateReleaseAsset({ owner, repo, asset_id: deb.id, name: newName });
+            core.info(`Renamed: ${deb.name} -> ${newName}`);
+            const sig = assets.find(a => a.name === `${deb.name}.sig`);
+            if (sig) {
+              await github.rest.repos.updateReleaseAsset({ owner, repo, asset_id: sig.id, name: `${newName}.sig` });
+              core.info(`Renamed: ${sig.name} -> ${newName}.sig`);
+            }
 
   build-ubuntu-26-04:
+    needs: create-release
     if: inputs.build-ubuntu-26-04 != false
     permissions:
       contents: write
     runs-on: ubuntu-26.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: false
-
-      - name: Inject version from tag
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+      - name: Set up Tauri build environment
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@fix-tauri-release
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ inputs.rust-version }}
-
-      - name: Install Linux system dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            libssl-dev \
-            libxdo-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
-
-      - name: Set up Bun
-        if: inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@v2
-        with:
+          rust-version: ${{ inputs.rust-version }}
+          install-linux-deps: "true"
+          package-manager: ${{ inputs.package-manager }}
           bun-version: ${{ inputs.bun-version }}
-
-      - name: Set up Node.js
-        if: inputs.package-manager == 'npm'
-        uses: actions/setup-node@v6
-        with:
           node-version: ${{ inputs.node-version }}
-          cache: npm
-
-      - name: Install frontend dependencies (bun)
-        if: inputs.package-manager == 'bun'
-        run: bun install
-        working-directory: ${{ inputs.frontend-dir }}
-
-      - name: Install frontend dependencies (npm)
-        if: inputs.package-manager == 'npm'
-        run: npm ci
-        working-directory: ${{ inputs.frontend-dir }}
+          frontend-dir: ${{ inputs.frontend-dir }}
 
       - name: Build and upload Tauri bundles
         uses: tauri-apps/tauri-action@v0
@@ -251,57 +228,55 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
-          releaseDraft: ${{ inputs.release-draft }}
-          prerelease: ${{ inputs.prerelease }}
-          args: ""
+          releaseId: ${{ needs.create-release.outputs.release-id }}
+          args: "--bundles appimage,deb"
+
+      - name: Rename deb asset to ubuntu2604 name
+        uses: actions/github-script@v9
+        env:
+          APP_BINARY_NAME: ${{ inputs.app-binary-name }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release-id }}
+        with:
+          script: |
+            const bin       = process.env.APP_BINARY_NAME;
+            const releaseId = parseInt(process.env.RELEASE_ID, 10);
+            const owner     = context.repo.owner;
+            const repo      = context.repo.repo;
+            const { data: assets } = await github.rest.repos.listReleaseAssets({
+              owner, repo, release_id: releaseId, per_page: 100,
+            });
+            // Match either the plain name or the .1-suffixed collision variant
+            const re = new RegExp(`^${bin}_([\\d.]+)_amd64(\\.1)?\\.deb$`, 'i');
+            const deb = assets.find(a => re.test(a.name));
+            if (!deb) { core.setFailed('ubuntu-26.04 .deb asset not found'); return; }
+            const version = deb.name.match(re)[1];
+            const newName = `${bin}_${version}_linux_ubuntu2604_amd64.deb`;
+            await github.rest.repos.updateReleaseAsset({ owner, repo, asset_id: deb.id, name: newName });
+            core.info(`Renamed: ${deb.name} -> ${newName}`);
+            const sig = assets.find(a => a.name === `${deb.name}.sig`);
+            if (sig) {
+              await github.rest.repos.updateReleaseAsset({ owner, repo, asset_id: sig.id, name: `${newName}.sig` });
+              core.info(`Renamed: ${sig.name} -> ${newName}.sig`);
+            }
 
   build-macos:
+    needs: create-release
     if: inputs.build-macos-arm != false
     permissions:
       contents: write
     runs-on: macos-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: false
-
-      - name: Inject version from tag
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+      - name: Set up Tauri build environment
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@fix-tauri-release
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          target: aarch64-apple-darwin
-
-      - name: Set up Bun
-        if: inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@v2
-        with:
+          rust-version: ${{ inputs.rust-version }}
+          rust-target: aarch64-apple-darwin
+          package-manager: ${{ inputs.package-manager }}
           bun-version: ${{ inputs.bun-version }}
-
-      - name: Set up Node.js
-        if: inputs.package-manager == 'npm'
-        uses: actions/setup-node@v6
-        with:
           node-version: ${{ inputs.node-version }}
-          cache: npm
-
-      - name: Install frontend dependencies (bun)
-        if: inputs.package-manager == 'bun'
-        run: bun install
-        working-directory: ${{ inputs.frontend-dir }}
-
-      - name: Install frontend dependencies (npm)
-        if: inputs.package-manager == 'npm'
-        run: npm ci
-        working-directory: ${{ inputs.frontend-dir }}
+          frontend-dir: ${{ inputs.frontend-dir }}
 
       - name: Build and upload Tauri bundles
         uses: tauri-apps/tauri-action@v0
@@ -310,56 +285,26 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
-          releaseDraft: ${{ inputs.release-draft }}
-          prerelease: ${{ inputs.prerelease }}
+          releaseId: ${{ needs.create-release.outputs.release-id }}
           args: "--target aarch64-apple-darwin"
 
   build-windows:
+    needs: create-release
     if: inputs.build-windows != false
     permissions:
       contents: write
     runs-on: windows-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: false
-
-      - name: Inject version from tag
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+      - name: Set up Tauri build environment
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@fix-tauri-release
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ inputs.rust-version }}
-
-      - name: Set up Bun
-        if: inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@v2
-        with:
+          rust-version: ${{ inputs.rust-version }}
+          package-manager: ${{ inputs.package-manager }}
           bun-version: ${{ inputs.bun-version }}
-
-      - name: Set up Node.js
-        if: inputs.package-manager == 'npm'
-        uses: actions/setup-node@v6
-        with:
           node-version: ${{ inputs.node-version }}
-          cache: npm
-
-      - name: Install frontend dependencies (bun)
-        if: inputs.package-manager == 'bun'
-        run: bun install
-        working-directory: ${{ inputs.frontend-dir }}
-
-      - name: Install frontend dependencies (npm)
-        if: inputs.package-manager == 'npm'
-        run: npm ci
-        working-directory: ${{ inputs.frontend-dir }}
+          frontend-dir: ${{ inputs.frontend-dir }}
 
       - name: Build and upload Tauri bundles
         uses: tauri-apps/tauri-action@v0
@@ -368,14 +313,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
-          releaseDraft: ${{ inputs.release-draft }}
-          prerelease: ${{ inputs.prerelease }}
+          releaseId: ${{ needs.create-release.outputs.release-id }}
           args: ""
 
   merge-updater-json:
     needs:
+      - create-release
       - build-ubuntu-24-04
       - build-ubuntu-26-04
       - build-macos
@@ -384,7 +327,7 @@ jobs:
       always() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     steps:
@@ -392,26 +335,31 @@ jobs:
         uses: actions/github-script@v9
         env:
           APP_BINARY_NAME: ${{ inputs.app-binary-name }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release-id }}
         with:
           script: |
-            const tagName   = context.ref.replace('refs/tags/', '');
+            const tagName     = context.ref.replace('refs/tags/', '');
             const fullVersion = tagName.replace(/^v/, '');
             // Strip pre-release suffix to match the version Tauri embedded in bundle filenames
-            const version   = fullVersion.replace(/[-+].*$/, '');
-            const owner     = context.repo.owner;
-            const repo      = context.repo.repo;
-            const bin       = process.env.APP_BINARY_NAME;   // e.g. "mdd-ui"
+            const version     = fullVersion.replace(/[-+].*$/, '');
+            const owner       = context.repo.owner;
+            const repo        = context.repo.repo;
+            const bin         = process.env.APP_BINARY_NAME;   // e.g. "mdd-ui"
+            const releaseId   = parseInt(process.env.RELEASE_ID, 10);
 
-            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag: tagName });
-            const releaseId = release.id;
+            if (!bin) {
+              core.setFailed('APP_BINARY_NAME is empty - pass app-binary-name when calling this workflow');
+              return;
+            }
 
             const { data: assets } = await github.rest.repos.listReleaseAssets({
               owner, repo, release_id: releaseId, per_page: 100,
             });
 
-            // Each rule matches the Tauri-generated bundle name, provides the
-            // new name (with OS/arch identifier) and the updater platform
-            // key - null means the bundle is for direct download only.
+            // Each rule matches the already-renamed asset name and provides the
+            // updater platform key - null means the bundle is for direct download only.
+            // .deb files are renamed by each build job immediately after upload,
+            // so by this point they already carry the ubuntu2404/ubuntu2604 suffix.
             const bundleRules = [
               // macOS aarch64
               {
@@ -424,36 +372,22 @@ jobs:
                 newName:    `${bin}_${version}_darwin_aarch64.dmg`,
                 updaterKey: null,
               },
-              // Linux x86_64 (ubuntu-24.04)
+              // Linux x86_64 - AppImage built once on ubuntu-26.04 (generic)
               {
                 match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.AppImage$`, 'i'),
-                newName:    `${bin}_${version}_linux_ubuntu2404_amd64.AppImage`,
+                newName:    `${bin}_${version}_linux_amd64.AppImage`,
                 updaterKey: 'linux-x86_64',
               },
+              // Linux .deb for ubuntu-24.04
               {
-                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.deb$`, 'i'),
+                match:      new RegExp(`^${bin}_[\\d.]+_linux_ubuntu2404_amd64\\.deb$`, 'i'),
                 newName:    `${bin}_${version}_linux_ubuntu2404_amd64.deb`,
                 updaterKey: null,
               },
+              // Linux .deb for ubuntu-26.04
               {
-                match:      new RegExp(`^${bin}-[\\d.]+-1\\.x86_64\\.rpm$`, 'i'),
-                newName:    `${bin}-${version}-1_linux_ubuntu2404_x86_64.rpm`,
-                updaterKey: null,
-              },
-              // Linux x86_64 (ubuntu-26.04) - GitHub appends .1 to duplicate asset names
-              {
-                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.1\\.AppImage$`, 'i'),
-                newName:    `${bin}_${version}_linux_ubuntu2604_amd64.AppImage`,
-                updaterKey: null,
-              },
-              {
-                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.1\\.deb$`, 'i'),
+                match:      new RegExp(`^${bin}_[\\d.]+_linux_ubuntu2604_amd64\\.deb$`, 'i'),
                 newName:    `${bin}_${version}_linux_ubuntu2604_amd64.deb`,
-                updaterKey: null,
-              },
-              {
-                match:      new RegExp(`^${bin}-[\\d.]+-1\\.x86_64\\.1\\.rpm$`, 'i'),
-                newName:    `${bin}-${version}-1_linux_ubuntu2604_x86_64.rpm`,
                 updaterKey: null,
               },
               // Windows x64

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -14,15 +14,19 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.*'
   workflow_call:
     inputs:
       app-name:
         description: >
-          Human-readable release name prefix, e.g. "MDD UI". Used in releaseName: "<app-name> ${{ github.ref_name }}".
+          Human-readable release name prefix, e.g. "MDD UI". Used in releaseName: "<app-name> <tag>".
         type: string
         required: true
 
       app-binary-name:
+        description: "Binary name of the app, e.g. \"mdd-ui\". Used for asset renaming."
+        type: string
+        required: true
 
       tauri-conf-path:
         description: "Relative path to tauri.conf.json (default: tauri.conf.json)"
@@ -59,11 +63,6 @@ on:
         type: string
         default: "stable"
 
-      tauri-action-version:
-        description: "Version of tauri-apps/tauri-action to use (default: v0)"
-        type: string
-        default: "v0"
-
       release-draft:
         description: "Publish release as a draft (default: false)"
         type: boolean
@@ -74,8 +73,13 @@ on:
         type: boolean
         default: false
 
-      build-linux:
+      build-ubuntu-24-04:
         description: "Include the Linux (ubuntu-24.04) build (default: true)"
+        type: boolean
+        default: true
+
+      build-ubuntu-26-04:
+        description: "Include the Linux (ubuntu-26.04) build (default: true)"
         type: boolean
         default: true
 
@@ -113,29 +117,11 @@ permissions:
   contents: write
 
 jobs:
-  build-tauri:
+  build-ubuntu-24-04:
+    if: inputs.build-ubuntu-24-04 != false
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: ubuntu-24.04
-            args: ""
-            rust_targets: ""
-            enabled: ${{ inputs.build-linux }}
-          - platform: macos-latest
-            args: "--target aarch64-apple-darwin"
-            rust_targets: "aarch64-apple-darwin"
-            enabled: ${{ inputs.build-macos-arm }}
-          - platform: windows-latest
-            args: ""
-            rust_targets: ""
-            enabled: ${{ inputs.build-windows }}
-
-    runs-on: ${{ matrix.platform }}
-    if: ${{ matrix.enabled }}
-
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -143,41 +129,17 @@ jobs:
           submodules: false
 
       - name: Inject version from tag
-        shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          python3 - << 'EOF'
-          import os, re, json
-
-          v = os.environ.get("VERSION") or os.environ.get("GITHUB_REF_NAME", "").lstrip("v")
-          tauri_conf = "${{ inputs.tauri-conf-path }}"
-          cargo_toml = "${{ inputs.cargo-toml-path }}"
-
-          with open(tauri_conf) as f:
-              cfg = json.load(f)
-          cfg["version"] = v
-          with open(tauri_conf, "w") as f:
-              json.dump(cfg, f, indent=2)
-              f.write("\n")
-
-          with open(cargo_toml) as f:
-              text = f.read()
-          # Replace version only in [package] section (first occurrence)
-          text = re.sub(r'^version = "[^"]+"', f'version = "{v}"', text, count=1, flags=re.MULTILINE)
-          with open(cargo_toml, "w") as f:
-              f.write(text)
-          EOF
-        env:
-          VERSION: ${{ github.ref_name }}
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+        with:
+          tauri-conf-path: ${{ inputs.tauri-conf-path }}
+          cargo-toml-path: ${{ inputs.cargo-toml-path }}
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ inputs.rust-version }}
-          targets: ${{ matrix.rust_targets }}
 
       - name: Install Linux system dependencies
-        if: matrix.platform == 'ubuntu-24.04'
         shell: bash
         run: |
           sudo apt-get update
@@ -213,7 +175,7 @@ jobs:
         working-directory: ${{ inputs.frontend-dir }}
 
       - name: Build and upload Tauri bundles
-        uses: tauri-apps/tauri-action@${{ inputs.tauri-action-version }}
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -223,11 +185,205 @@ jobs:
           releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
           releaseDraft: ${{ inputs.release-draft }}
           prerelease: ${{ inputs.prerelease }}
-          args: ${{ matrix.args }}
+          args: ""
+
+  build-ubuntu-26-04:
+    if: inputs.build-ubuntu-26-04 != false
+    permissions:
+      contents: write
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Inject version from tag
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+        with:
+          tauri-conf-path: ${{ inputs.tauri-conf-path }}
+          cargo-toml-path: ${{ inputs.cargo-toml-path }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ inputs.rust-version }}
+
+      - name: Install Linux system dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            libssl-dev \
+            libxdo-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Set up Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Set up Node.js
+        if: inputs.package-manager == 'npm'
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install frontend dependencies (bun)
+        if: inputs.package-manager == 'bun'
+        run: bun install
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Install frontend dependencies (npm)
+        if: inputs.package-manager == 'npm'
+        run: npm ci
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Build and upload Tauri bundles
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
+          releaseDraft: ${{ inputs.release-draft }}
+          prerelease: ${{ inputs.prerelease }}
+          args: ""
+
+  build-macos:
+    if: inputs.build-macos-arm != false
+    permissions:
+      contents: write
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Inject version from tag
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+        with:
+          tauri-conf-path: ${{ inputs.tauri-conf-path }}
+          cargo-toml-path: ${{ inputs.cargo-toml-path }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          target: aarch64-apple-darwin
+
+      - name: Set up Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Set up Node.js
+        if: inputs.package-manager == 'npm'
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install frontend dependencies (bun)
+        if: inputs.package-manager == 'bun'
+        run: bun install
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Install frontend dependencies (npm)
+        if: inputs.package-manager == 'npm'
+        run: npm ci
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Build and upload Tauri bundles
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
+          releaseDraft: ${{ inputs.release-draft }}
+          prerelease: ${{ inputs.prerelease }}
+          args: "--target aarch64-apple-darwin"
+
+  build-windows:
+    if: inputs.build-windows != false
+    permissions:
+      contents: write
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Inject version from tag
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/inject-version@fix-tauri-release
+        with:
+          tauri-conf-path: ${{ inputs.tauri-conf-path }}
+          cargo-toml-path: ${{ inputs.cargo-toml-path }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ inputs.rust-version }}
+
+      - name: Set up Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Set up Node.js
+        if: inputs.package-manager == 'npm'
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+
+      - name: Install frontend dependencies (bun)
+        if: inputs.package-manager == 'bun'
+        run: bun install
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Install frontend dependencies (npm)
+        if: inputs.package-manager == 'npm'
+        run: npm ci
+        working-directory: ${{ inputs.frontend-dir }}
+
+      - name: Build and upload Tauri bundles
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "${{ inputs.app-name }} ${{ github.ref_name }}"
+          releaseDraft: ${{ inputs.release-draft }}
+          prerelease: ${{ inputs.prerelease }}
+          args: ""
 
   merge-updater-json:
     needs:
-      - build-tauri
+      - build-ubuntu-24-04
+      - build-ubuntu-26-04
+      - build-macos
+      - build-windows
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -239,13 +395,12 @@ jobs:
         with:
           script: |
             const tagName   = context.ref.replace('refs/tags/', '');
-            const version   = tagName.replace(/^v/, '');
+            const fullVersion = tagName.replace(/^v/, '');
+            // Strip pre-release suffix to match the version Tauri embedded in bundle filenames
+            const version   = fullVersion.replace(/[-+].*$/, '');
             const owner     = context.repo.owner;
             const repo      = context.repo.repo;
             const bin       = process.env.APP_BINARY_NAME;   // e.g. "mdd-ui"
-            // Tauri uses underscores in some asset names and hyphens in others.
-            // Build both variants to match reliably.
-            const binU      = bin.replace(/-/g, '_');         // e.g. "mdd_ui"
 
             const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag: tagName });
             const releaseId = release.id;
@@ -269,30 +424,46 @@ jobs:
                 newName:    `${bin}_${version}_darwin_aarch64.dmg`,
                 updaterKey: null,
               },
-              // Linux x86_64
+              // Linux x86_64 (ubuntu-24.04)
               {
-                match:      new RegExp(`^${binU}_[\\d.]+_amd64\\.AppImage$`, 'i'),
-                newName:    `${bin}_${version}_linux_amd64.AppImage`,
+                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.AppImage$`, 'i'),
+                newName:    `${bin}_${version}_linux_ubuntu2404_amd64.AppImage`,
                 updaterKey: 'linux-x86_64',
               },
               {
-                match:      new RegExp(`^${binU}_[\\d.]+_amd64\\.deb$`, 'i'),
-                newName:    `${bin}_${version}_linux_amd64.deb`,
+                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.deb$`, 'i'),
+                newName:    `${bin}_${version}_linux_ubuntu2404_amd64.deb`,
                 updaterKey: null,
               },
               {
                 match:      new RegExp(`^${bin}-[\\d.]+-1\\.x86_64\\.rpm$`, 'i'),
-                newName:    `${bin}-${version}-1_linux_x86_64.rpm`,
+                newName:    `${bin}-${version}-1_linux_ubuntu2404_x86_64.rpm`,
+                updaterKey: null,
+              },
+              // Linux x86_64 (ubuntu-26.04) - GitHub appends .1 to duplicate asset names
+              {
+                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.1\\.AppImage$`, 'i'),
+                newName:    `${bin}_${version}_linux_ubuntu2604_amd64.AppImage`,
+                updaterKey: null,
+              },
+              {
+                match:      new RegExp(`^${bin}_[\\d.]+_amd64\\.1\\.deb$`, 'i'),
+                newName:    `${bin}_${version}_linux_ubuntu2604_amd64.deb`,
+                updaterKey: null,
+              },
+              {
+                match:      new RegExp(`^${bin}-[\\d.]+-1\\.x86_64\\.1\\.rpm$`, 'i'),
+                newName:    `${bin}-${version}-1_linux_ubuntu2604_x86_64.rpm`,
                 updaterKey: null,
               },
               // Windows x64
               {
-                match:      new RegExp(`^${binU}_[\\d.]+_x64-setup\\.exe$`, 'i'),
+                match:      new RegExp(`^${bin}_[\\d.]+_x64-setup\\.exe$`, 'i'),
                 newName:    `${bin}_${version}_windows_x64-setup.exe`,
                 updaterKey: 'windows-x86_64',
               },
               {
-                match:      new RegExp(`^${binU}_[\\d.]+_x64_en-US\\.msi$`, 'i'),
+                match:      new RegExp(`^${bin}_[\\d.]+_x64_en-US\\.msi$`, 'i'),
                 newName:    `${bin}_${version}_windows_x64_en-US.msi`,
                 updaterKey: null,
               },


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- Remove '${{ github.ref_name }}' from workflow_call input description string (context expressions disallowed in descriptions)
- Remove 'tauri-action-version' input and hardcode tauri-action@v0, as dynamic expressions are not allowed in 'uses:' fields
- Replace '${{ inputs.build-* }}' matrix values and '${{ matrix.enabled }}' job-level if-condition with direct 'inputs.*' context checks in the job 'if:' expression, which is a supported context for that field


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)