### PR TITLE
fix: pin tauri-build-setup ref to a valid commit SHA

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - name: Set up Tauri build environment
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@8815a69eba44f830247f2b4efde484676f6ac6fe
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@6939750edbd364cee103a4b176b67b012c0e2c19
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - name: Set up Tauri build environment
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@8815a69eba44f830247f2b4efde484676f6ac6fe
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@6939750edbd364cee103a4b176b67b012c0e2c19
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
@@ -267,7 +267,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Set up Tauri build environment
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@8815a69eba44f830247f2b4efde484676f6ac6fe
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@6939750edbd364cee103a4b176b67b012c0e2c19
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}
@@ -296,7 +296,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Set up Tauri build environment
-        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@8815a69eba44f830247f2b4efde484676f6ac6fe
+        uses: eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@6939750edbd364cee103a4b176b67b012c0e2c19
         with:
           tauri-conf-path: ${{ inputs.tauri-conf-path }}
           cargo-toml-path: ${{ inputs.cargo-toml-path }}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

`tauri-release.yml` referenced `tauri-build-setup` at a SHA that did
not exist in the repository. This caused all 4 build jobs (ubuntu-24.04,
ubuntu-26.04, macOS, Windows) to fail immediately with:

```
Unable to resolve action `eclipse-opensovd/cicd-workflows/.github/actions/tauri-build-setup@<sha>`
```

This fix replaces the phantom SHA with `6939750` — the parent commit on
`main` where the correct `tauri-build-setup` action is present and
`inject-version` is already pinned to a valid SHA.

## Checklist

<!-- Do NOT add, remove, or reword items -->
- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

- Fixes broken release pipeline in eclipse-opensovd/mdd-ui#11

## Notes for Reviewers

Tested end-to-end via mdd-ui release workflow against this branch — all
4 build jobs passed.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)