### PR TITLE
fix: use rustfmtl.toml from repo if exists

### DIFF
--- a/shared-config/.rustfmt.toml
+++ b/shared-config/.rustfmt.toml
@@ -8,7 +8,6 @@
 # terms of the Apache License Version 2.0 which is available at
 # https://www.apache.org/licenses/LICENSE-2.0
 style_edition = "2024"
-max_width = 100
 newline_style = "Unix"
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"

--- a/shared-config/cargo-fmt.sh
+++ b/shared-config/cargo-fmt.sh
@@ -17,7 +17,12 @@ if [ ! -f Cargo.toml ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUSTFMT_TOML="$SCRIPT_DIR/.rustfmt.toml"
+
+RUSTFMT_TOML=".rustfmt.toml"
+if [ ! -f "$RUSTFMT_TOML" ]; then
+    echo "WARN: $RUSTFMT_TOML not found in the current directory. Using $RUSTFMT_TOML from script directory." >&2
+    RUSTFMT_TOML="$SCRIPT_DIR/.rustfmt.toml"
+fi
 
 CHECK_FLAG=""
 if [[ "${1:-}" == "--check" ]]; then
@@ -25,5 +30,5 @@ if [[ "${1:-}" == "--check" ]]; then
 fi
 
 # shellcheck disable=SC2086
-exec cargo fmt --all $CHECK_FLAG -- \
+exec cargo +nightly fmt --all $CHECK_FLAG -- \
     --config-path "$RUSTFMT_TOML"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

- Use .rustfmt.toml of the downstreamproject if exists. Fallback to ci/cd version if not found.
- Run cargo fmt with `+nightly` flag to ensure it works correctly in a local setup where nightly might not be set as the default toolchain.
- Remove `max_width` from the required settings as this might be reasonable to have configured differently on the downstream projects.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)