### PR TITLE
fix: ensure nightly toolchain is available for fmt

### DIFF
--- a/pre-commit-action/action.yml
+++ b/pre-commit-action/action.yml
@@ -21,6 +21,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Install Rust nightly toolchain (required for rustfmt check)
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: nightly
+        components: rustfmt
+        cache-shared-key: ci-nightly
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

As the format invocations requires the nightly toolchain due to the configured flags, we need to ensure it is always installed in the pre-commit action.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
