### PR TITLE
chore: pin all workflows to ubuntu-26.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   cargo-build-test:
     name: Cargo Build & Test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 
@@ -62,7 +62,7 @@ jobs:
   bazel-build-test:
     name: Bazel Build & Test
     if: ${{ inputs.bazel-enabled }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   checks:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,7 @@ permissions:
 jobs:
   coverage:
     name: Code Coverage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       IGNORE_REGEX: ${{ inputs.ignore-filename-regex }}
     steps:

--- a/.github/workflows/crap-baseline.yml
+++ b/.github/workflows/crap-baseline.yml
@@ -82,7 +82,7 @@ permissions:
 jobs:
   update-baseline:
     name: Update CRAP Baseline
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -69,7 +69,7 @@ permissions:
 jobs:
   crap:
     name: CRAP Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   cargo-miri:
     name: Miri (Undefined Behavior Check)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       MIRIFLAGS: ${{ inputs.miri-flags }}
     steps:

--- a/.github/workflows/post-pr-comments.yml
+++ b/.github/workflows/post-pr-comments.yml
@@ -60,7 +60,7 @@ permissions:
 jobs:
   post-comments:
     name: Post PR Comments
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Download comment artifacts
         env:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Runs pre-commit hooks with standardized configuration:
 ```yaml
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Run checks
         # Or use a long SHA instead of a branch (recommended)
@@ -96,7 +96,7 @@ jobs:
   format_and_clippy_nightly_toolchain_pinned:
     concurrency:
       group: format_and_clippy_nightly_toolchain_pinned-${{ github.ref }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     continue-on-error: false
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes #55

Signed-off-by: Sharanamma Hosur h.sharanamma@gmail.com>

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
