### PR TITLE
fix: handle malformed YAML/TOML configs

### DIFF
--- a/pre-commit-action/check-hooks-installed.py
+++ b/pre-commit-action/check-hooks-installed.py
@@ -283,7 +283,25 @@ def _is_superset(canonical: dict, actual: dict, path: str = "") -> list[str]:
     return issues
 
 
+def _load_yaml(path: Path) -> tuple[dict | None, str | None]:
+    """Parse a YAML file, returning (data, None) on success or (None, error) on failure."""
+    try:
+        return yaml.safe_load(path.read_text()) or {}, None
+    except yaml.YAMLError as e:
+        return None, f"Failed to parse {path} as YAML: {e}"
+
+
+def _load_toml(path: Path) -> tuple[dict | None, str | None]:
+    """Parse a TOML file, returning (data, None) on success or (None, error) on failure."""
+    try:
+        return tomllib.loads(path.read_text()), None
+    except tomllib.TOMLDecodeError as e:
+        return None, f"Failed to parse {path} as TOML: {e}"
+
+
 def check_configs(failures: list[str], has_rust: bool) -> None:
+    loaders = {"yaml_superset": _load_yaml, "toml_superset": _load_toml}
+
     for cfg in REQUIRED_CONFIGS:
         if cfg["rust_only"] and not has_rust:
             continue
@@ -298,19 +316,17 @@ def check_configs(failures: list[str], has_rust: bool) -> None:
             continue
 
         check_mode = cfg.get("check_mode", "exact")
+        loader = loaders.get(check_mode)
 
-        if check_mode == "yaml_superset":
-            canonical_data = yaml.safe_load(canonical_path.read_text()) or {}
-            actual_data = yaml.safe_load(p.read_text()) or {}
-            issues = _is_superset(canonical_data, actual_data)
-            if issues:
-                failures.append(
-                    f"Config file {cfg['path']} is missing required settings:\n"
-                    + "".join(f"  - {issue}\n" for issue in issues)
-                )
-        elif check_mode == "toml_superset":
-            canonical_data = tomllib.loads(canonical_path.read_text())
-            actual_data = tomllib.loads(p.read_text())
+        if loader is not None:
+            canonical_data, error = loader(canonical_path)
+            if error:
+                failures.append(error)
+                continue
+            actual_data, error = loader(p)
+            if error:
+                failures.append(error)
+                continue
             issues = _is_superset(canonical_data, actual_data)
             if issues:
                 failures.append(

--- a/shared-lints/check_cargo_lints.py
+++ b/shared-lints/check_cargo_lints.py
@@ -130,8 +130,17 @@ def main():
         sys.exit(1)
 
     # Load lints
-    shared_lints = load_shared_lints(shared_lints_path)
-    cargo_lints = load_cargo_lints(cargo_toml_path)
+    try:
+        shared_lints = load_shared_lints(shared_lints_path)
+    except tomllib.TOMLDecodeError as e:
+        print(f"Error: failed to parse {shared_lints_path} as TOML: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        cargo_lints = load_cargo_lints(cargo_toml_path)
+    except tomllib.TOMLDecodeError as e:
+        print(f"Error: failed to parse {cargo_toml_path} as TOML: {e}", file=sys.stderr)
+        sys.exit(1)
 
     # Compare
     missing, mismatched = compare_lints(shared_lints, cargo_lints)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->
## Problem

pre-commit-action/check-hooks-installed.py and shared-lints/check_cargo_lints.py previously raised unhandled exceptions when given malformed config files:

- yaml.YAMLError from yaml.safe_load() in check_configs() when a YAML config (e.g. `.yamlfmt`, `.markdownlint.yaml`) contains a syntax error
- tomllib.TOMLDecodeError from tomllib.loads() in load_shared_lints() /
  load_cargo_lints() when shared-lints.toml or Cargo.toml is malformed

In both cases, CI output was a raw Python traceback rather than an actionable
failure message, making it confusing for contributors to diagnose the problem.

## Changes

- Added _load_yaml() and _load_toml() helper functions in check-hooks-installed.py that return (data, error) tuples, catching yaml.YAMLError and tomllib.TOMLDecodeError respectively
- Refactored check_configs() to use these helpers via a dispatch dict,appending a clean [FAIL] message to the failures list on parse error
- Wrapped the load_shared_lints() and load_cargo_lints() calls in check_cargo_lints.py main() with try/except, printing a clean **Error: failed to parse <file> as TOML: <reason> message and exiting 1**

## Checklist
- [x] I have tested my changes locally

