### PR TITLE
feat: add reusable conventional-commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Conventional Commits
+
+on:
+  workflow_call:
+    inputs:
+      validate-pr-title:
+        description: "Validate PR title against Conventional Commits format"
+        type: boolean
+        default: true
+      validate-commits:
+        description: >
+          Validate individual commit subjects in the PR using prek with the conventional-pre-commit hook from the caller's .pre-commit-config.yaml
+        type: boolean
+        default: true
+      types:
+        description: >
+          Newline-separated list of allowed conventional commit types for PR title validation (via amannn/action-semantic-pull-request). Commit subject validation uses the types configured in the caller's .pre-commit-config.yaml.
+        type: string
+        default: |
+          feat
+          fix
+          docs
+          style
+          refactor
+          perf
+          test
+          build
+          ci
+          chore
+          revert
+      scopes:
+        description: "Newline-separated list of allowed scopes for PR title validation (empty = any scope allowed)"
+        type: string
+        default: ""
+      require-scope:
+        description: "Require a scope in PR title"
+        type: boolean
+        default: false
+      subject-pattern:
+        description: "Regex pattern the PR title subject (text after type/scope) must match"
+        type: string
+        default: ""
+      subject-pattern-error:
+        description: "Error message when subject-pattern fails"
+        type: string
+        default: ""
+      ignore-authors:
+        description: "Newline-separated list of commit author emails to ignore (e.g. bots)"
+        type: string
+        default: ""
+      prek-version:
+        description: "Version of prek to install (empty = latest)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: PR Title
+    if: ${{ inputs.validate-pr-title && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: ${{ inputs.types }}
+          scopes: ${{ inputs.scopes }}
+          requireScope: ${{ inputs.require-scope }}
+          subjectPattern: ${{ inputs.subject-pattern }}
+          subjectPatternError: ${{ inputs.subject-pattern-error }}
+
+  commit-subjects:
+    name: Commit Subjects
+    if: ${{ inputs.validate-commits && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install prek
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.prek-version }}" ]]; then
+            uv tool install "prek==${{ inputs.prek-version }}"
+          else
+            uv tool install prek
+          fi
+
+      - name: Validate commit subjects
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IGNORE_AUTHORS: ${{ inputs.ignore-authors }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          declare -A ignore_map
+          while IFS= read -r email; do
+            email=$(echo "$email" | xargs)
+            [[ -n "$email" ]] && ignore_map["$email"]=1
+          done <<< "$IGNORE_AUTHORS"
+
+          fail=0
+          for sha in $(git rev-list "$BASE_SHA..$HEAD_SHA"); do
+            author_email=$(git log -1 --format='%ae' "$sha")
+            if [[ -n "${ignore_map[$author_email]:-}" ]]; then
+              continue
+            fi
+
+            git log -1 --format=%B "$sha" > /tmp/commit-msg
+            if ! prek run --hook-stage commit-msg \
+                --commit-msg-filename /tmp/commit-msg conventional-pre-commit; then
+              echo "::error::Non-conventional commit: $(git log -1 --format='%h %s' "$sha")"
+              fail=1
+            fi
+          done
+          exit "$fail"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,52 @@ When a formatter makes changes to your code, the pre-commit hook fails, requirin
 - `allowed-unicode-chars`: Comma-separated Unicode characters permitted in files checked by `no-unicode-extensions` (e.g. `"µ,§"`).
   Empty by default.
 
+### Using the Conventional Commits Workflow
+
+The `conventional-commits.yml` workflow validates PR titles and individual commit messages against the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+Commit subject validation uses [prek](https://prek.j178.dev/) to run the `conventional-pre-commit` hook from the caller's `.pre-commit-config.yaml`. This ensures CI validates exactly what developers see locally.
+
+**Prerequisites**: The calling repository must have a `.pre-commit-config.yaml` with the `conventional-pre-commit` hook configured:
+
+```yaml
+# .pre-commit-config.yaml (in your repository)
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+```
+
+**Usage**:
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  conventional-commits:
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/conventional-commits.yml@main
+    with:
+      validate-pr-title: true
+      validate-commits: true
+```
+
+#### Available Inputs
+
+- `validate-pr-title` (optional): Validate PR title against Conventional Commits format. Defaults to `true`.
+- `validate-commits` (optional): Validate individual commit subjects using prek with the caller's `.pre-commit-config.yaml`. Defaults to `true`.
+- `types` (optional): Newline-separated list of allowed conventional commit types for PR title validation. Commit subject validation uses types from the caller's `.pre-commit-config.yaml`. Defaults to `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+- `scopes` (optional): Newline-separated list of allowed scopes for PR title validation. Empty means any scope is allowed.
+- `require-scope` (optional): Require a scope in PR title. Defaults to `false`.
+- `subject-pattern` (optional): Regex pattern the PR title subject must match.
+- `subject-pattern-error` (optional): Error message when `subject-pattern` fails.
+- `ignore-authors` (optional): Newline-separated list of commit author emails to skip (e.g. bot accounts).
+- `prek-version` (optional): Version of prek to install. Defaults to latest.
+
 ## Running Checks Locally
 
 Run all pre-commit hooks on your repository using [prek](https://github.com/j178/prek):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add conventional-commits.yml reusable workflow that validates PR titles (via amannn/action-semantic-pull-request@v6) and individual commit messages (via conventional-pre-commit) against the Conventional Commits specification.

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Related to #40

## Notes for Reviewers

Split from #40 to keep PRs focused on specific workflow changes.

---
Alexander Mohr <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/eclipse-opensovd/.github/blob/main/PROVIDER_INFORMATION.md)