### PR TITLE
feat: add reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: >
+          Release version string. Typically the git tag (e.g. "v1.2.3") or a rolling identifier like "nightly" or "latest". Used for archive names and the GitHub Release title.
+        type: string
+        required: true
+      artifact-pattern:
+        description: >
+          Pattern for actions/download-artifact to match build artifacts. Each matching artifact directory is expected to contain the binary. Example: "my-app-*" matches "my-app-x86_64-unknown-linux-gnu", etc.
+        type: string
+        required: true
+      binary-name:
+        description: >
+          Base name of the binary inside each artifact directory (without extension). Windows artifacts are expected to have a .exe suffix automatically. Example: "opensovd-gateway"
+        type: string
+        required: true
+      git-cliff-version:
+        description: "Version of git-cliff to install"
+        type: string
+        default: "2.11.0"
+      git-cliff-args:
+        description: >
+          Extra arguments for git-cliff (e.g. "--config cliff.toml"). The workflow automatically uses --unreleased for nightly/latest and --current for versioned tags.
+        type: string
+        default: ""
+      attestation:
+        description: "Generate build provenance attestation for release artifacts"
+        type: boolean
+        default: true
+      prerelease:
+        description: >
+          Mark the release as a prerelease. When not explicitly set, nightly and latest releases are automatically marked as prereleases.
+        type: boolean
+        default: false
+      delete-existing:
+        description: >
+          Delete an existing release with the same tag before creating a new one. Useful for rolling releases (nightly, latest).
+        type: boolean
+        default: false
+      draft:
+        description: "Create the release as a draft"
+        type: boolean
+        default: false
+      archive-prefix:
+        description: >
+          Prefix for archive filenames. Defaults to the binary-name input. Archives are named: <prefix>-<version>-<target>.<ext>
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  attestations: write
+  id-token: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff@${{ inputs.git-cliff-version }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          path: artifacts
+
+      - name: Generate changelog
+        shell: bash
+        run: |
+          VERSION="${{ inputs.version }}"
+          EXTRA_ARGS="${{ inputs.git-cliff-args }}"
+          if [[ "$VERSION" == "nightly" || "$VERSION" == "latest" ]]; then
+            git cliff --unreleased $EXTRA_ARGS -o CHANGELOG.md
+          else
+            git cliff --current $EXTRA_ARGS -o CHANGELOG.md
+          fi
+
+      - name: Package artifacts
+        shell: bash
+        run: |
+          VERSION="${{ inputs.version }}"
+          BINARY="${{ inputs.binary-name }}"
+          PREFIX="${{ inputs.archive-prefix }}"
+          PREFIX="${PREFIX:-$BINARY}"
+
+          mkdir -p release
+
+          for dir in artifacts/${BINARY}-*/; do
+            [ -d "$dir" ] || continue
+            target=$(basename "$dir" | sed "s/${BINARY}-//")
+
+            if [[ "$target" == *windows* ]]; then
+              zip "release/${PREFIX}-${VERSION}-${target}.zip" "${dir}${BINARY}.exe"
+            else
+              chmod +x "${dir}${BINARY}"
+              tar -czf "release/${PREFIX}-${VERSION}-${target}.tar.gz" -C "$dir" "$BINARY"
+            fi
+          done
+
+          cd release
+          for file in *.tar.gz *.zip; do
+            [ -f "$file" ] || continue
+            sha512sum "$file" > "$file.sha512"
+          done
+
+      - name: Attest build provenance
+        if: ${{ inputs.attestation }}
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'release/*'
+
+      - name: Delete existing release
+        if: ${{ inputs.delete-existing }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release delete "${{ inputs.version }}" --yes --cleanup-tag || true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          ARGS=()
+          ARGS+=(--title "$VERSION")
+          ARGS+=(--notes-file CHANGELOG.md)
+
+          if [[ "${{ inputs.draft }}" == "true" ]]; then
+            ARGS+=(--draft)
+          fi
+
+          if [[ "${{ inputs.prerelease }}" == "true" ]]; then
+            ARGS+=(--prerelease)
+          elif [[ "$VERSION" == "nightly" || "$VERSION" == "latest" ]]; then
+            ARGS+=(--prerelease)
+          fi
+
+          gh release create "$VERSION" "${ARGS[@]}" release/*

--- a/README.md
+++ b/README.md
@@ -176,6 +176,52 @@ When a formatter makes changes to your code, the pre-commit hook fails, requirin
 - `allowed-unicode-chars`: Comma-separated Unicode characters permitted in files checked by `no-unicode-extensions` (e.g. `"µ,§"`).
   Empty by default.
 
+### Using the Release Workflow
+
+The `release.yml` workflow packages build artifacts into platform archives, generates a changelog with git-cliff, creates SHA-512 checksums, optionally attests build provenance, and publishes a GitHub Release.
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    # Your build matrix that uploads artifacts named like:
+    #   my-app-x86_64-unknown-linux-gnu
+    #   my-app-aarch64-unknown-linux-gnu
+    #   my-app-x86_64-pc-windows-msvc
+    # Each artifact contains the binary (e.g. "my-app" or "my-app.exe").
+    ...
+
+  release:
+    needs: build
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/release.yml@main
+    with:
+      version: ${{ github.ref_name }}
+      artifact-pattern: "my-app-*"
+      binary-name: "my-app"
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+```
+
+#### Available Inputs
+
+- `version` (required): Release version string (e.g. `v1.2.3`, `nightly`, `latest`). Used for archive names and the GitHub Release title.
+- `artifact-pattern` (required): Pattern for `actions/download-artifact` to match build artifacts (e.g. `my-app-*`).
+- `binary-name` (required): Base name of the binary inside each artifact directory, without extension. Windows artifacts are expected to have a `.exe` suffix.
+- `git-cliff-version` (optional): Version of git-cliff to install. Defaults to `2.11.0`.
+- `git-cliff-args` (optional): Extra arguments for git-cliff (e.g. `--config cliff.toml`). The workflow automatically uses `--unreleased` for nightly/latest and `--current` for versioned tags.
+- `attestation` (optional): Generate build provenance attestation for release artifacts. Defaults to `true`.
+- `prerelease` (optional): Mark the release as a prerelease. Nightly and latest releases are automatically marked as prereleases. Defaults to `false`.
+- `delete-existing` (optional): Delete an existing release with the same tag before creating a new one. Useful for rolling releases. Defaults to `false`.
+- `draft` (optional): Create the release as a draft. Defaults to `false`.
+- `archive-prefix` (optional): Prefix for archive filenames. Defaults to the `binary-name` input.
+
 ## Running Checks Locally
 
 Run all pre-commit hooks on your repository using [prek](https://github.com/j178/prek):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add release.yml reusable workflow that packages build artifacts into platform archives, generates changelogs with git-cliff, creates SHA-512 checksums, optionally attests build provenance, and publishes GitHub Releases.

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Related to #40

## Notes for Reviewers

Split from #40 to keep PRs focused on specific workflow changes.

---
Alexander Mohr <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/eclipse-opensovd/.github/blob/main/PROVIDER_INFORMATION.md)